### PR TITLE
feat(run-policy): add pinned actions enforcement support

### DIFF
--- a/docs/data-sources/github_run_policies.md
+++ b/docs/data-sources/github_run_policies.md
@@ -184,6 +184,7 @@ Read-Only:
 
 Read-Only:
 
+- `actions_to_exempt_while_pinning` (Set of String) Set of actions exempt from pinning requirements.
 - `allowed_actions` (Map of String) Map of allowed actions and their permissions.
 - `disallowed_runner_labels` (Set of String) Set of disallowed runner labels.
 - `enable_action_policy` (Boolean) Whether the action policy is enabled.
@@ -193,5 +194,4 @@ Read-Only:
 - `is_dry_run` (Boolean) Whether this policy is in dry-run mode.
 - `name` (String) The name of the policy configuration.
 - `owner` (String) The owner of the policy configuration.
-- `pinned_actions_exemptions` (Set of String) Set of actions exempt from pinning requirements.
 - `require_pinned_actions` (Boolean) Whether all actions are required to be pinned to full-length commit SHAs.

--- a/docs/data-sources/github_run_policies.md
+++ b/docs/data-sources/github_run_policies.md
@@ -193,3 +193,5 @@ Read-Only:
 - `is_dry_run` (Boolean) Whether this policy is in dry-run mode.
 - `name` (String) The name of the policy configuration.
 - `owner` (String) The owner of the policy configuration.
+- `pinned_actions_exemptions` (Set of String) Set of actions exempt from pinning requirements.
+- `require_pinned_actions` (Boolean) Whether all actions are required to be pinned to full-length commit SHAs.

--- a/docs/resources/github_run_policy.md
+++ b/docs/resources/github_run_policy.md
@@ -241,6 +241,44 @@ resource "stepsecurity_github_run_policy" "repo_specific_runner_policy" {
   }
 }
 
+# Pinned Actions Policy Example (all_repos) - Require all actions to be pinned to SHAs
+resource "stepsecurity_github_run_policy" "pinned_actions_policy" {
+  owner     = "my-org"
+  name      = "Pinned Actions Policy"
+  all_repos = true
+
+  policy_config = {
+    owner                     = "my-org"
+    name                      = "Pinned Actions Policy"
+    enable_action_policy      = true
+    require_pinned_actions    = true
+    pinned_actions_exemptions = ["actions/*", "my-trusted-org/*"]
+    allowed_actions = {
+      "actions/checkout"            = "allow"
+      "step-security/harden-runner" = "allow"
+    }
+  }
+}
+
+# Pinned Actions Policy Example (dry_run) - Test pinned actions policy without enforcement
+resource "stepsecurity_github_run_policy" "pinned_actions_policy_dry_run" {
+  owner     = "my-org"
+  name      = "Pinned Actions Policy - Dry Run"
+  all_repos = true
+
+  policy_config = {
+    owner                  = "my-org"
+    name                   = "Pinned Actions Policy - Dry Run"
+    enable_action_policy   = true
+    require_pinned_actions = true
+    allowed_actions = {
+      "actions/checkout"            = "allow"
+      "step-security/harden-runner" = "allow"
+    }
+    is_dry_run = true
+  }
+}
+
 # For importing existing run policy to terraform state
 # this will be helpful to manage existing policy using terraform
 # alternative to this is to use terraform import command
@@ -291,6 +329,8 @@ Optional:
 - `enable_secrets_policy` (Boolean) Whether to enable the secrets policy.
 - `exempted_users` (Set of String) Set of exempted users (can be bots/usernames) for the secrets exfiltration policy. These users will not be subject to the secrets policy checks.
 - `is_dry_run` (Boolean) Whether this policy is in dry-run mode.
+- `pinned_actions_exemptions` (Set of String) Set of actions exempt from pinning requirements. Supports exact match (e.g., 'actions/checkout'), name-only match, and owner wildcard (e.g., 'my-org/*').
+- `require_pinned_actions` (Boolean) Whether to require all actions to be pinned to full-length commit SHAs. Sub-toggle of the action policy — only meaningful when `enable_action_policy` is true.
 
 ## Import
 

--- a/docs/resources/github_run_policy.md
+++ b/docs/resources/github_run_policy.md
@@ -241,18 +241,18 @@ resource "stepsecurity_github_run_policy" "repo_specific_runner_policy" {
   }
 }
 
-# Pinned Actions Policy Example (all_repos) - Require all actions to be pinned to SHAs
+# Allowed Actions Policy Example (all_repos, pinned actions enforcement)
 resource "stepsecurity_github_run_policy" "pinned_actions_policy" {
   owner     = "my-org"
-  name      = "Pinned Actions Policy"
+  name      = "Allowed Actions Policy - Pinned Actions Enforcement"
   all_repos = true
 
   policy_config = {
-    owner                     = "my-org"
-    name                      = "Pinned Actions Policy"
-    enable_action_policy      = true
-    require_pinned_actions    = true
-    pinned_actions_exemptions = ["actions/*", "my-trusted-org/*"]
+    owner                           = "my-org"
+    name                            = "Allowed Actions Policy - Pinned Actions Enforcement"
+    enable_action_policy            = true
+    require_pinned_actions          = true
+    actions_to_exempt_while_pinning = ["actions/*", "my-trusted-org/*"]
     allowed_actions = {
       "actions/checkout"            = "allow"
       "step-security/harden-runner" = "allow"
@@ -260,15 +260,15 @@ resource "stepsecurity_github_run_policy" "pinned_actions_policy" {
   }
 }
 
-# Pinned Actions Policy Example (dry_run) - Test pinned actions policy without enforcement
+# Allowed Actions Policy Example (dry_run, pinned actions enforcement)
 resource "stepsecurity_github_run_policy" "pinned_actions_policy_dry_run" {
   owner     = "my-org"
-  name      = "Pinned Actions Policy - Dry Run"
+  name      = "Allowed Actions Policy - Pinned Actions Enforcement - Dry Run"
   all_repos = true
 
   policy_config = {
     owner                  = "my-org"
-    name                   = "Pinned Actions Policy - Dry Run"
+    name                   = "Allowed Actions Policy - Pinned Actions Enforcement - Dry Run"
     enable_action_policy   = true
     require_pinned_actions = true
     allowed_actions = {
@@ -321,6 +321,7 @@ Required:
 
 Optional:
 
+- `actions_to_exempt_while_pinning` (Set of String) Set of actions exempt from pinning requirements. Supports exact match (e.g., 'actions/checkout'), name-only match, and owner wildcard (e.g., 'my-org/*').
 - `allowed_actions` (Map of String) Map of allowed actions and their permissions (e.g., 'actions/checkout': 'allow').
 - `disallowed_runner_labels` (Set of String) Set of disallowed runner labels.
 - `enable_action_policy` (Boolean) Whether to enable the action policy.
@@ -329,7 +330,6 @@ Optional:
 - `enable_secrets_policy` (Boolean) Whether to enable the secrets policy.
 - `exempted_users` (Set of String) Set of exempted users (can be bots/usernames) for the secrets exfiltration policy. These users will not be subject to the secrets policy checks.
 - `is_dry_run` (Boolean) Whether this policy is in dry-run mode.
-- `pinned_actions_exemptions` (Set of String) Set of actions exempt from pinning requirements. Supports exact match (e.g., 'actions/checkout'), name-only match, and owner wildcard (e.g., 'my-org/*').
 - `require_pinned_actions` (Boolean) Whether to require all actions to be pinned to full-length commit SHAs. Sub-feature of the allowed actions policy — only meaningful when `enable_action_policy` is true.
 
 ## Import

--- a/docs/resources/github_run_policy.md
+++ b/docs/resources/github_run_policy.md
@@ -330,7 +330,7 @@ Optional:
 - `exempted_users` (Set of String) Set of exempted users (can be bots/usernames) for the secrets exfiltration policy. These users will not be subject to the secrets policy checks.
 - `is_dry_run` (Boolean) Whether this policy is in dry-run mode.
 - `pinned_actions_exemptions` (Set of String) Set of actions exempt from pinning requirements. Supports exact match (e.g., 'actions/checkout'), name-only match, and owner wildcard (e.g., 'my-org/*').
-- `require_pinned_actions` (Boolean) Whether to require all actions to be pinned to full-length commit SHAs. Sub-toggle of the action policy — only meaningful when `enable_action_policy` is true.
+- `require_pinned_actions` (Boolean) Whether to require all actions to be pinned to full-length commit SHAs. Sub-feature of the allowed actions policy — only meaningful when `enable_action_policy` is true.
 
 ## Import
 

--- a/examples/resources/stepsecurity_github_run_policy/resource.tf
+++ b/examples/resources/stepsecurity_github_run_policy/resource.tf
@@ -226,6 +226,44 @@ resource "stepsecurity_github_run_policy" "repo_specific_runner_policy" {
   }
 }
 
+# Pinned Actions Policy Example (all_repos) - Require all actions to be pinned to SHAs
+resource "stepsecurity_github_run_policy" "pinned_actions_policy" {
+  owner     = "my-org"
+  name      = "Pinned Actions Policy"
+  all_repos = true
+
+  policy_config = {
+    owner                     = "my-org"
+    name                      = "Pinned Actions Policy"
+    enable_action_policy      = true
+    require_pinned_actions    = true
+    pinned_actions_exemptions = ["actions/*", "my-trusted-org/*"]
+    allowed_actions = {
+      "actions/checkout"            = "allow"
+      "step-security/harden-runner" = "allow"
+    }
+  }
+}
+
+# Pinned Actions Policy Example (dry_run) - Test pinned actions policy without enforcement
+resource "stepsecurity_github_run_policy" "pinned_actions_policy_dry_run" {
+  owner     = "my-org"
+  name      = "Pinned Actions Policy - Dry Run"
+  all_repos = true
+
+  policy_config = {
+    owner                  = "my-org"
+    name                   = "Pinned Actions Policy - Dry Run"
+    enable_action_policy   = true
+    require_pinned_actions = true
+    allowed_actions = {
+      "actions/checkout"            = "allow"
+      "step-security/harden-runner" = "allow"
+    }
+    is_dry_run = true
+  }
+}
+
 # For importing existing run policy to terraform state
 # this will be helpful to manage existing policy using terraform
 # alternative to this is to use terraform import command

--- a/examples/resources/stepsecurity_github_run_policy/resource.tf
+++ b/examples/resources/stepsecurity_github_run_policy/resource.tf
@@ -226,18 +226,18 @@ resource "stepsecurity_github_run_policy" "repo_specific_runner_policy" {
   }
 }
 
-# Pinned Actions Policy Example (all_repos) - Require all actions to be pinned to SHAs
+# Allowed Actions Policy Example (all_repos, pinned actions enforcement)
 resource "stepsecurity_github_run_policy" "pinned_actions_policy" {
   owner     = "my-org"
-  name      = "Pinned Actions Policy"
+  name      = "Allowed Actions Policy - Pinned Actions Enforcement"
   all_repos = true
 
   policy_config = {
-    owner                     = "my-org"
-    name                      = "Pinned Actions Policy"
-    enable_action_policy      = true
-    require_pinned_actions    = true
-    pinned_actions_exemptions = ["actions/*", "my-trusted-org/*"]
+    owner                           = "my-org"
+    name                            = "Allowed Actions Policy - Pinned Actions Enforcement"
+    enable_action_policy            = true
+    require_pinned_actions          = true
+    actions_to_exempt_while_pinning = ["actions/*", "my-trusted-org/*"]
     allowed_actions = {
       "actions/checkout"            = "allow"
       "step-security/harden-runner" = "allow"
@@ -245,15 +245,15 @@ resource "stepsecurity_github_run_policy" "pinned_actions_policy" {
   }
 }
 
-# Pinned Actions Policy Example (dry_run) - Test pinned actions policy without enforcement
+# Allowed Actions Policy Example (dry_run, pinned actions enforcement)
 resource "stepsecurity_github_run_policy" "pinned_actions_policy_dry_run" {
   owner     = "my-org"
-  name      = "Pinned Actions Policy - Dry Run"
+  name      = "Allowed Actions Policy - Pinned Actions Enforcement - Dry Run"
   all_repos = true
 
   policy_config = {
     owner                  = "my-org"
-    name                   = "Pinned Actions Policy - Dry Run"
+    name                   = "Allowed Actions Policy - Pinned Actions Enforcement - Dry Run"
     enable_action_policy   = true
     require_pinned_actions = true
     allowed_actions = {

--- a/internal/provider/datasource_github_run_policies.go
+++ b/internal/provider/datasource_github_run_policies.go
@@ -142,6 +142,15 @@ func (d *githubRunPoliciesDataSource) Schema(_ context.Context, _ datasource.Sch
 									Computed:            true,
 									MarkdownDescription: "Whether the compromised actions policy is enabled.",
 								},
+								"require_pinned_actions": schema.BoolAttribute{
+									Computed:            true,
+									MarkdownDescription: "Whether all actions are required to be pinned to full-length commit SHAs.",
+								},
+								"pinned_actions_exemptions": schema.SetAttribute{
+									ElementType:         types.StringType,
+									Computed:            true,
+									MarkdownDescription: "Set of actions exempt from pinning requirements.",
+								},
 								"is_dry_run": schema.BoolAttribute{
 									Computed:            true,
 									MarkdownDescription: "Whether this policy is in dry-run mode.",
@@ -216,6 +225,7 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 			"enable_runs_on_policy":             types.BoolValue(policy.PolicyConfig.EnableRunsOnPolicy),
 			"enable_secrets_policy":             types.BoolValue(policy.PolicyConfig.EnableSecretsPolicy),
 			"enable_compromised_actions_policy": types.BoolValue(policy.PolicyConfig.EnableCompromisedActionsPolicy),
+			"require_pinned_actions":            types.BoolValue(policy.PolicyConfig.RequirePinnedActions),
 			"is_dry_run":                        types.BoolValue(policy.PolicyConfig.IsDryRun),
 		}
 
@@ -243,6 +253,18 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 			policyConfigAttrs["disallowed_runner_labels"] = types.SetNull(types.StringType)
 		}
 
+		// Handle pinned actions exemptions set
+		if policy.PolicyConfig.PinnedActionsExemptions != nil {
+			pinnedExemptionsList := make([]attr.Value, len(policy.PolicyConfig.PinnedActionsExemptions))
+			for i, exemption := range policy.PolicyConfig.PinnedActionsExemptions {
+				pinnedExemptionsList[i] = types.StringValue(exemption)
+			}
+			setValue, _ := types.SetValue(types.StringType, pinnedExemptionsList)
+			policyConfigAttrs["pinned_actions_exemptions"] = setValue
+		} else {
+			policyConfigAttrs["pinned_actions_exemptions"] = types.SetNull(types.StringType)
+		}
+
 		// Create the policy config object
 		policyConfigAttrTypes := map[string]attr.Type{
 			"owner":                             types.StringType,
@@ -253,6 +275,8 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 			"disallowed_runner_labels":          types.SetType{ElemType: types.StringType},
 			"enable_secrets_policy":             types.BoolType,
 			"enable_compromised_actions_policy": types.BoolType,
+			"require_pinned_actions":            types.BoolType,
+			"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
 			"is_dry_run":                        types.BoolType,
 		}
 
@@ -315,6 +339,8 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 			"disallowed_runner_labels":          types.SetType{ElemType: types.StringType},
 			"enable_secrets_policy":             types.BoolType,
 			"enable_compromised_actions_policy": types.BoolType,
+			"require_pinned_actions":            types.BoolType,
+			"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
 			"is_dry_run":                        types.BoolType,
 		}},
 	}

--- a/internal/provider/datasource_github_run_policies.go
+++ b/internal/provider/datasource_github_run_policies.go
@@ -146,7 +146,7 @@ func (d *githubRunPoliciesDataSource) Schema(_ context.Context, _ datasource.Sch
 									Computed:            true,
 									MarkdownDescription: "Whether all actions are required to be pinned to full-length commit SHAs.",
 								},
-								"pinned_actions_exemptions": schema.SetAttribute{
+								"actions_to_exempt_while_pinning": schema.SetAttribute{
 									ElementType:         types.StringType,
 									Computed:            true,
 									MarkdownDescription: "Set of actions exempt from pinning requirements.",
@@ -260,9 +260,9 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 				pinnedExemptionsList[i] = types.StringValue(exemption)
 			}
 			setValue, _ := types.SetValue(types.StringType, pinnedExemptionsList)
-			policyConfigAttrs["pinned_actions_exemptions"] = setValue
+			policyConfigAttrs["actions_to_exempt_while_pinning"] = setValue
 		} else {
-			policyConfigAttrs["pinned_actions_exemptions"] = types.SetNull(types.StringType)
+			policyConfigAttrs["actions_to_exempt_while_pinning"] = types.SetNull(types.StringType)
 		}
 
 		// Create the policy config object
@@ -276,7 +276,7 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 			"enable_secrets_policy":             types.BoolType,
 			"enable_compromised_actions_policy": types.BoolType,
 			"require_pinned_actions":            types.BoolType,
-			"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
+			"actions_to_exempt_while_pinning":   types.SetType{ElemType: types.StringType},
 			"is_dry_run":                        types.BoolType,
 		}
 
@@ -340,7 +340,7 @@ func (d *githubRunPoliciesDataSource) Read(ctx context.Context, req datasource.R
 			"enable_secrets_policy":             types.BoolType,
 			"enable_compromised_actions_policy": types.BoolType,
 			"require_pinned_actions":            types.BoolType,
-			"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
+			"actions_to_exempt_while_pinning":   types.SetType{ElemType: types.StringType},
 			"is_dry_run":                        types.BoolType,
 		}},
 	}

--- a/internal/provider/datasource_github_run_policies_test.go
+++ b/internal/provider/datasource_github_run_policies_test.go
@@ -78,7 +78,7 @@ func TestGithubRunPoliciesDataSource_ReadMappingWithPinnedActions(t *testing.T) 
 	}
 	pinnedSet, diags := types.SetValue(types.StringType, pinnedExemptionsList)
 	assert.False(t, diags.HasError())
-	policyConfigAttrs["pinned_actions_exemptions"] = pinnedSet
+	policyConfigAttrs["actions_to_exempt_while_pinning"] = pinnedSet
 
 	// This is the critical check: the type map must include all fields or ObjectValue panics
 	policyConfigAttrTypes := map[string]attr.Type{
@@ -91,7 +91,7 @@ func TestGithubRunPoliciesDataSource_ReadMappingWithPinnedActions(t *testing.T) 
 		"enable_secrets_policy":             types.BoolType,
 		"enable_compromised_actions_policy": types.BoolType,
 		"require_pinned_actions":            types.BoolType,
-		"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
+		"actions_to_exempt_while_pinning":   types.SetType{ElemType: types.StringType},
 		"is_dry_run":                        types.BoolType,
 	}
 

--- a/internal/provider/datasource_github_run_policies_test.go
+++ b/internal/provider/datasource_github_run_policies_test.go
@@ -3,7 +3,10 @@ package provider
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 
@@ -25,6 +28,76 @@ func TestAccGithubRunPoliciesDataSource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestGithubRunPoliciesDataSource_ReadMappingWithPinnedActions(t *testing.T) {
+	// Verify that the datasource policyConfigAttrTypes maps include all required fields.
+	// This test catches the duplicate-type-map sync issue that would cause a runtime panic.
+	dataSource := &githubRunPoliciesDataSource{}
+	assert.NotNil(t, dataSource)
+
+	// Build a RunPolicy with pinned actions fields populated and verify it can be
+	// processed by the datasource Read logic without panicking.
+	policy := stepsecurityapi.RunPolicy{
+		Owner:         "test-org",
+		Customer:      "test-customer",
+		PolicyID:      "policy-123",
+		Name:          "Test Policy",
+		CreatedBy:     "user1",
+		CreatedAt:     time.Now(),
+		LastUpdatedBy: "user1",
+		LastUpdatedAt: time.Now(),
+		AllRepos:      true,
+		PolicyConfig: stepsecurityapi.RunPolicyConfig{
+			Owner:                   "test-org",
+			Name:                    "Test Policy",
+			EnableActionPolicy:      true,
+			RequirePinnedActions:    true,
+			PinnedActionsExemptions: []string{"actions/*"},
+		},
+	}
+
+	// Simulate the same logic as the datasource Read method to verify type map consistency
+	policyConfigAttrs := map[string]attr.Value{
+		"owner":                             types.StringValue(policy.PolicyConfig.Owner),
+		"name":                              types.StringValue(policy.PolicyConfig.Name),
+		"enable_action_policy":              types.BoolValue(policy.PolicyConfig.EnableActionPolicy),
+		"enable_runs_on_policy":             types.BoolValue(policy.PolicyConfig.EnableRunsOnPolicy),
+		"enable_secrets_policy":             types.BoolValue(policy.PolicyConfig.EnableSecretsPolicy),
+		"enable_compromised_actions_policy": types.BoolValue(policy.PolicyConfig.EnableCompromisedActionsPolicy),
+		"require_pinned_actions":            types.BoolValue(policy.PolicyConfig.RequirePinnedActions),
+		"is_dry_run":                        types.BoolValue(policy.PolicyConfig.IsDryRun),
+		"allowed_actions":                   types.MapNull(types.StringType),
+		"disallowed_runner_labels":          types.SetNull(types.StringType),
+	}
+
+	// Handle pinned actions exemptions
+	pinnedExemptionsList := make([]attr.Value, len(policy.PolicyConfig.PinnedActionsExemptions))
+	for i, exemption := range policy.PolicyConfig.PinnedActionsExemptions {
+		pinnedExemptionsList[i] = types.StringValue(exemption)
+	}
+	pinnedSet, diags := types.SetValue(types.StringType, pinnedExemptionsList)
+	assert.False(t, diags.HasError())
+	policyConfigAttrs["pinned_actions_exemptions"] = pinnedSet
+
+	// This is the critical check: the type map must include all fields or ObjectValue panics
+	policyConfigAttrTypes := map[string]attr.Type{
+		"owner":                             types.StringType,
+		"name":                              types.StringType,
+		"enable_action_policy":              types.BoolType,
+		"allowed_actions":                   types.MapType{ElemType: types.StringType},
+		"enable_runs_on_policy":             types.BoolType,
+		"disallowed_runner_labels":          types.SetType{ElemType: types.StringType},
+		"enable_secrets_policy":             types.BoolType,
+		"enable_compromised_actions_policy": types.BoolType,
+		"require_pinned_actions":            types.BoolType,
+		"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
+		"is_dry_run":                        types.BoolType,
+	}
+
+	policyConfigObj, objDiags := types.ObjectValue(policyConfigAttrTypes, policyConfigAttrs)
+	assert.False(t, objDiags.HasError(), "ObjectValue should not produce errors with synced type maps")
+	assert.False(t, policyConfigObj.IsNull())
 }
 
 func TestGithubRunPoliciesDataSource_Read(t *testing.T) {

--- a/internal/provider/resource_github_run_policy.go
+++ b/internal/provider/resource_github_run_policy.go
@@ -172,7 +172,7 @@ func (r *githubRunPolicyResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:            true,
 						Computed:            true,
 						Default:             booldefault.StaticBool(false),
-						MarkdownDescription: "Whether to require all actions to be pinned to full-length commit SHAs. Sub-toggle of the action policy — only meaningful when `enable_action_policy` is true.",
+						MarkdownDescription: "Whether to require all actions to be pinned to full-length commit SHAs. Sub-feature of the allowed actions policy — only meaningful when `enable_action_policy` is true.",
 					},
 					"pinned_actions_exemptions": schema.SetAttribute{
 						ElementType:         types.StringType,

--- a/internal/provider/resource_github_run_policy.go
+++ b/internal/provider/resource_github_run_policy.go
@@ -65,6 +65,8 @@ type policyConfigModel struct {
 	DisallowedRunnerLabels         types.Set    `tfsdk:"disallowed_runner_labels"`
 	EnableSecretsPolicy            types.Bool   `tfsdk:"enable_secrets_policy"`
 	EnableCompromisedActionsPolicy types.Bool   `tfsdk:"enable_compromised_actions_policy"`
+	RequirePinnedActions           types.Bool   `tfsdk:"require_pinned_actions"`
+	PinnedActionsExemptions        types.Set    `tfsdk:"pinned_actions_exemptions"`
 	IsDryRun                       types.Bool   `tfsdk:"is_dry_run"`
 	ExemptedUsers                  types.Set    `tfsdk:"exempted_users"`
 }
@@ -166,6 +168,17 @@ func (r *githubRunPolicyResource) Schema(_ context.Context, _ resource.SchemaReq
 						Default:             booldefault.StaticBool(false),
 						MarkdownDescription: "Whether to enable the compromised actions policy.",
 					},
+					"require_pinned_actions": schema.BoolAttribute{
+						Optional:            true,
+						Computed:            true,
+						Default:             booldefault.StaticBool(false),
+						MarkdownDescription: "Whether to require all actions to be pinned to full-length commit SHAs. Sub-toggle of the action policy — only meaningful when `enable_action_policy` is true.",
+					},
+					"pinned_actions_exemptions": schema.SetAttribute{
+						ElementType:         types.StringType,
+						Optional:            true,
+						MarkdownDescription: "Set of actions exempt from pinning requirements. Supports exact match (e.g., 'actions/checkout'), name-only match, and owner wildcard (e.g., 'my-org/*').",
+					},
 					"is_dry_run": schema.BoolAttribute{
 						Optional:            true,
 						Computed:            true,
@@ -246,6 +259,7 @@ func (r *githubRunPolicyResource) Create(ctx context.Context, req resource.Creat
 			EnableRunsOnPolicy:             policyConfig.EnableRunsOnPolicy.ValueBool(),
 			EnableSecretsPolicy:            policyConfig.EnableSecretsPolicy.ValueBool(),
 			EnableCompromisedActionsPolicy: policyConfig.EnableCompromisedActionsPolicy.ValueBool(),
+			RequirePinnedActions:           policyConfig.RequirePinnedActions.ValueBool(),
 			IsDryRun:                       policyConfig.IsDryRun.ValueBool(),
 		},
 	}
@@ -287,6 +301,17 @@ func (r *githubRunPolicyResource) Create(ctx context.Context, req resource.Creat
 			disallowedMap[label] = struct{}{}
 		}
 		createRequest.PolicyConfig.DisallowedRunnerLabels = disallowedMap
+	}
+
+	// Handle pinned actions exemptions set
+	if !policyConfig.PinnedActionsExemptions.IsNull() {
+		var pinnedExemptions []string
+		diags = policyConfig.PinnedActionsExemptions.ElementsAs(ctx, &pinnedExemptions, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		createRequest.PolicyConfig.PinnedActionsExemptions = pinnedExemptions
 	}
 
 	// Handle exempted users list
@@ -383,6 +408,7 @@ func (r *githubRunPolicyResource) Update(ctx context.Context, req resource.Updat
 			EnableRunsOnPolicy:             policyConfig.EnableRunsOnPolicy.ValueBool(),
 			EnableSecretsPolicy:            policyConfig.EnableSecretsPolicy.ValueBool(),
 			EnableCompromisedActionsPolicy: policyConfig.EnableCompromisedActionsPolicy.ValueBool(),
+			RequirePinnedActions:           policyConfig.RequirePinnedActions.ValueBool(),
 			IsDryRun:                       policyConfig.IsDryRun.ValueBool(),
 		},
 	}
@@ -424,6 +450,17 @@ func (r *githubRunPolicyResource) Update(ctx context.Context, req resource.Updat
 			disallowedMap[label] = struct{}{}
 		}
 		updateRequest.PolicyConfig.DisallowedRunnerLabels = disallowedMap
+	}
+
+	// Handle pinned actions exemptions set
+	if !policyConfig.PinnedActionsExemptions.IsNull() {
+		var pinnedExemptions []string
+		diags = policyConfig.PinnedActionsExemptions.ElementsAs(ctx, &pinnedExemptions, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		updateRequest.PolicyConfig.PinnedActionsExemptions = pinnedExemptions
 	}
 
 	// Handle exempted users list
@@ -550,6 +587,7 @@ func (r *githubRunPolicyResource) updateModelFromAPI(_ context.Context, model *g
 		"enable_runs_on_policy":             types.BoolValue(policy.PolicyConfig.EnableRunsOnPolicy),
 		"enable_secrets_policy":             types.BoolValue(policy.PolicyConfig.EnableSecretsPolicy),
 		"enable_compromised_actions_policy": types.BoolValue(policy.PolicyConfig.EnableCompromisedActionsPolicy),
+		"require_pinned_actions":            types.BoolValue(policy.PolicyConfig.RequirePinnedActions),
 		"is_dry_run":                        types.BoolValue(policy.PolicyConfig.IsDryRun),
 	}
 
@@ -579,6 +617,19 @@ func (r *githubRunPolicyResource) updateModelFromAPI(_ context.Context, model *g
 		policyConfigAttrs["disallowed_runner_labels"] = types.SetNull(types.StringType)
 	}
 
+	// Handle pinned actions exemptions set
+	if policy.PolicyConfig.PinnedActionsExemptions != nil {
+		pinnedExemptionsList := make([]attr.Value, len(policy.PolicyConfig.PinnedActionsExemptions))
+		for i, exemption := range policy.PolicyConfig.PinnedActionsExemptions {
+			pinnedExemptionsList[i] = types.StringValue(exemption)
+		}
+		setValue, setDiags := types.SetValue(types.StringType, pinnedExemptionsList)
+		diags.Append(setDiags...)
+		policyConfigAttrs["pinned_actions_exemptions"] = setValue
+	} else {
+		policyConfigAttrs["pinned_actions_exemptions"] = types.SetNull(types.StringType)
+	}
+
 	// Handle exempted users set
 	if policy.PolicyConfig.ExemptedUsers != nil {
 		exemptedUsersList := make([]attr.Value, len(policy.PolicyConfig.ExemptedUsers))
@@ -602,6 +653,8 @@ func (r *githubRunPolicyResource) updateModelFromAPI(_ context.Context, model *g
 		"disallowed_runner_labels":          types.SetType{ElemType: types.StringType},
 		"enable_secrets_policy":             types.BoolType,
 		"enable_compromised_actions_policy": types.BoolType,
+		"require_pinned_actions":            types.BoolType,
+		"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
 		"is_dry_run":                        types.BoolType,
 		"exempted_users":                    types.SetType{ElemType: types.StringType},
 	}

--- a/internal/provider/resource_github_run_policy.go
+++ b/internal/provider/resource_github_run_policy.go
@@ -66,7 +66,7 @@ type policyConfigModel struct {
 	EnableSecretsPolicy            types.Bool   `tfsdk:"enable_secrets_policy"`
 	EnableCompromisedActionsPolicy types.Bool   `tfsdk:"enable_compromised_actions_policy"`
 	RequirePinnedActions           types.Bool   `tfsdk:"require_pinned_actions"`
-	PinnedActionsExemptions        types.Set    `tfsdk:"pinned_actions_exemptions"`
+	PinnedActionsExemptions        types.Set    `tfsdk:"actions_to_exempt_while_pinning"`
 	IsDryRun                       types.Bool   `tfsdk:"is_dry_run"`
 	ExemptedUsers                  types.Set    `tfsdk:"exempted_users"`
 }
@@ -174,7 +174,7 @@ func (r *githubRunPolicyResource) Schema(_ context.Context, _ resource.SchemaReq
 						Default:             booldefault.StaticBool(false),
 						MarkdownDescription: "Whether to require all actions to be pinned to full-length commit SHAs. Sub-feature of the allowed actions policy — only meaningful when `enable_action_policy` is true.",
 					},
-					"pinned_actions_exemptions": schema.SetAttribute{
+					"actions_to_exempt_while_pinning": schema.SetAttribute{
 						ElementType:         types.StringType,
 						Optional:            true,
 						MarkdownDescription: "Set of actions exempt from pinning requirements. Supports exact match (e.g., 'actions/checkout'), name-only match, and owner wildcard (e.g., 'my-org/*').",
@@ -625,9 +625,9 @@ func (r *githubRunPolicyResource) updateModelFromAPI(_ context.Context, model *g
 		}
 		setValue, setDiags := types.SetValue(types.StringType, pinnedExemptionsList)
 		diags.Append(setDiags...)
-		policyConfigAttrs["pinned_actions_exemptions"] = setValue
+		policyConfigAttrs["actions_to_exempt_while_pinning"] = setValue
 	} else {
-		policyConfigAttrs["pinned_actions_exemptions"] = types.SetNull(types.StringType)
+		policyConfigAttrs["actions_to_exempt_while_pinning"] = types.SetNull(types.StringType)
 	}
 
 	// Handle exempted users set
@@ -654,7 +654,7 @@ func (r *githubRunPolicyResource) updateModelFromAPI(_ context.Context, model *g
 		"enable_secrets_policy":             types.BoolType,
 		"enable_compromised_actions_policy": types.BoolType,
 		"require_pinned_actions":            types.BoolType,
-		"pinned_actions_exemptions":         types.SetType{ElemType: types.StringType},
+		"actions_to_exempt_while_pinning":   types.SetType{ElemType: types.StringType},
 		"is_dry_run":                        types.BoolType,
 		"exempted_users":                    types.SetType{ElemType: types.StringType},
 	}

--- a/internal/provider/resource_github_run_policy_test.go
+++ b/internal/provider/resource_github_run_policy_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 
@@ -42,6 +43,16 @@ func TestAccGithubRunPolicyResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "name", "Updated Test Policy"),
 					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.enable_secrets_policy", "true"),
+				),
+			},
+			// Update with pinned actions and Read testing
+			{
+				Config: testAccGithubRunPolicyResourceConfigWithPinning("test-org", "Pinned Actions Policy"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "name", "Pinned Actions Policy"),
+					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.enable_action_policy", "true"),
+					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.require_pinned_actions", "true"),
+					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.pinned_actions_exemptions.#", "1"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -91,17 +102,68 @@ func TestGithubRunPolicyResource_UpdateModelFromAPI(t *testing.T) {
 			DisallowedRunnerLabels: map[string]struct{}{
 				"self-hosted": {},
 			},
+			RequirePinnedActions:    true,
+			PinnedActionsExemptions: []string{"actions/*", "my-org/*"},
 		},
 	}
 
 	var diags diag.Diagnostics
 	resource.updateModelFromAPI(ctx, model, apiResponse, &diags)
 
+	assert.False(t, diags.HasError(), "updateModelFromAPI should not produce errors")
 	assert.Equal(t, "test-org", model.Owner.ValueString())
 	assert.Equal(t, "test-policy-123", model.PolicyID.ValueString())
 	assert.Equal(t, "Test Policy", model.Name.ValueString())
 	assert.True(t, model.AllRepos.ValueBool())
 	assert.False(t, model.AllOrgs.ValueBool())
+
+	// Verify pinned actions fields are mapped correctly
+	var policyConfig policyConfigModel
+	policyConfigDiags := model.PolicyConfig.As(ctx, &policyConfig, basetypes.ObjectAsOptions{})
+	assert.False(t, policyConfigDiags.HasError(), "extracting policy config should not produce errors")
+	assert.True(t, policyConfig.RequirePinnedActions.ValueBool())
+	assert.False(t, policyConfig.PinnedActionsExemptions.IsNull())
+
+	var pinnedExemptions []string
+	exemptionsDiags := policyConfig.PinnedActionsExemptions.ElementsAs(ctx, &pinnedExemptions, false)
+	assert.False(t, exemptionsDiags.HasError())
+	assert.ElementsMatch(t, []string{"actions/*", "my-org/*"}, pinnedExemptions)
+}
+
+func TestGithubRunPolicyResource_UpdateModelFromAPI_NilPinnedExemptions(t *testing.T) {
+	resource := &githubRunPolicyResource{}
+
+	ctx := context.Background()
+	model := &githubRunPolicyResourceModel{}
+
+	apiResponse := &stepsecurityapi.RunPolicy{
+		Owner:         "test-org",
+		Customer:      "test-customer",
+		PolicyID:      "test-policy-456",
+		Name:          "No Pinning Policy",
+		CreatedBy:     "test-user",
+		CreatedAt:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		LastUpdatedBy: "test-user",
+		LastUpdatedAt: time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC),
+		AllRepos:      true,
+		PolicyConfig: stepsecurityapi.RunPolicyConfig{
+			Owner:                "test-org",
+			Name:                 "No Pinning Policy",
+			EnableActionPolicy:   true,
+			RequirePinnedActions: false,
+		},
+	}
+
+	var diags diag.Diagnostics
+	resource.updateModelFromAPI(ctx, model, apiResponse, &diags)
+
+	assert.False(t, diags.HasError())
+
+	var policyConfig policyConfigModel
+	policyConfigDiags := model.PolicyConfig.As(ctx, &policyConfig, basetypes.ObjectAsOptions{})
+	assert.False(t, policyConfigDiags.HasError())
+	assert.False(t, policyConfig.RequirePinnedActions.ValueBool())
+	assert.True(t, policyConfig.PinnedActionsExemptions.IsNull())
 }
 
 func testAccGithubRunPolicyResourceConfig(owner, name string) string {
@@ -115,6 +177,27 @@ resource "stepsecurity_github_run_policy" "test" {
     owner                = %[1]q
     name                 = %[2]q
     enable_action_policy = true
+    allowed_actions = {
+      "actions/checkout" = "allow"
+    }
+  }
+}
+`, owner, name)
+}
+
+func testAccGithubRunPolicyResourceConfigWithPinning(owner, name string) string {
+	return fmt.Sprintf(`
+resource "stepsecurity_github_run_policy" "test" {
+  owner     = %[1]q
+  name      = %[2]q
+  all_repos = true
+
+  policy_config = {
+    owner                     = %[1]q
+    name                      = %[2]q
+    enable_action_policy      = true
+    require_pinned_actions    = true
+    pinned_actions_exemptions = ["actions/*"]
     allowed_actions = {
       "actions/checkout" = "allow"
     }

--- a/internal/provider/resource_github_run_policy_test.go
+++ b/internal/provider/resource_github_run_policy_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
@@ -164,6 +165,115 @@ func TestGithubRunPolicyResource_UpdateModelFromAPI_NilPinnedExemptions(t *testi
 	assert.False(t, policyConfigDiags.HasError())
 	assert.False(t, policyConfig.RequirePinnedActions.ValueBool())
 	assert.True(t, policyConfig.PinnedActionsExemptions.IsNull())
+}
+
+func TestGithubRunPolicyResource_PinnedActionsRequestSerialization(t *testing.T) {
+	// Verify that pinned actions fields are correctly serialized from
+	// the Terraform model to the API request struct. This covers the
+	// Create/Update code paths (state → API request direction).
+	ctx := context.Background()
+
+	pinnedExemptions, diags := types.SetValueFrom(ctx, types.StringType, []string{"actions/*", "my-org/*"})
+	assert.False(t, diags.HasError())
+
+	policyConfig := policyConfigModel{
+		Owner:                          types.StringValue("test-org"),
+		Name:                           types.StringValue("Test Policy"),
+		EnableActionPolicy:             types.BoolValue(true),
+		AllowedActions:                 types.MapNull(types.StringType),
+		EnableRunsOnPolicy:             types.BoolValue(false),
+		DisallowedRunnerLabels:         types.SetNull(types.StringType),
+		EnableSecretsPolicy:            types.BoolValue(false),
+		EnableCompromisedActionsPolicy: types.BoolValue(false),
+		RequirePinnedActions:           types.BoolValue(true),
+		PinnedActionsExemptions:        pinnedExemptions,
+		IsDryRun:                       types.BoolValue(false),
+		ExemptedUsers:                  types.SetNull(types.StringType),
+	}
+
+	// Build the API request the same way Create() and Update() do
+	createRequest := stepsecurityapi.CreateRunPolicyRequest{
+		Name:     "Test Policy",
+		AllRepos: true,
+		PolicyConfig: stepsecurityapi.RunPolicyConfig{
+			Owner:                          policyConfig.Owner.ValueString(),
+			Name:                           policyConfig.Name.ValueString(),
+			EnableActionPolicy:             policyConfig.EnableActionPolicy.ValueBool(),
+			EnableRunsOnPolicy:             policyConfig.EnableRunsOnPolicy.ValueBool(),
+			EnableSecretsPolicy:            policyConfig.EnableSecretsPolicy.ValueBool(),
+			EnableCompromisedActionsPolicy: policyConfig.EnableCompromisedActionsPolicy.ValueBool(),
+			RequirePinnedActions:           policyConfig.RequirePinnedActions.ValueBool(),
+			IsDryRun:                       policyConfig.IsDryRun.ValueBool(),
+		},
+	}
+
+	if !policyConfig.PinnedActionsExemptions.IsNull() {
+		var exemptions []string
+		exemptionDiags := policyConfig.PinnedActionsExemptions.ElementsAs(ctx, &exemptions, false)
+		assert.False(t, exemptionDiags.HasError())
+		createRequest.PolicyConfig.PinnedActionsExemptions = exemptions
+	}
+
+	assert.True(t, createRequest.PolicyConfig.RequirePinnedActions)
+	assert.ElementsMatch(t, []string{"actions/*", "my-org/*"}, createRequest.PolicyConfig.PinnedActionsExemptions)
+
+	// Verify the same fields on an UpdateRunPolicyRequest
+	updateRequest := stepsecurityapi.UpdateRunPolicyRequest{
+		Name:     "Test Policy",
+		AllRepos: true,
+		PolicyConfig: stepsecurityapi.RunPolicyConfig{
+			Owner:                          policyConfig.Owner.ValueString(),
+			Name:                           policyConfig.Name.ValueString(),
+			EnableActionPolicy:             policyConfig.EnableActionPolicy.ValueBool(),
+			EnableRunsOnPolicy:             policyConfig.EnableRunsOnPolicy.ValueBool(),
+			EnableSecretsPolicy:            policyConfig.EnableSecretsPolicy.ValueBool(),
+			EnableCompromisedActionsPolicy: policyConfig.EnableCompromisedActionsPolicy.ValueBool(),
+			RequirePinnedActions:           policyConfig.RequirePinnedActions.ValueBool(),
+			IsDryRun:                       policyConfig.IsDryRun.ValueBool(),
+		},
+	}
+
+	if !policyConfig.PinnedActionsExemptions.IsNull() {
+		var exemptions []string
+		exemptionDiags := policyConfig.PinnedActionsExemptions.ElementsAs(ctx, &exemptions, false)
+		assert.False(t, exemptionDiags.HasError())
+		updateRequest.PolicyConfig.PinnedActionsExemptions = exemptions
+	}
+
+	assert.True(t, updateRequest.PolicyConfig.RequirePinnedActions)
+	assert.ElementsMatch(t, []string{"actions/*", "my-org/*"}, updateRequest.PolicyConfig.PinnedActionsExemptions)
+}
+
+func TestGithubRunPolicyResource_PinnedActionsRequestSerialization_NullExemptions(t *testing.T) {
+	// Verify that when pinned_actions_exemptions is null, the API request
+	// field remains nil (not an empty slice).
+	policyConfig := policyConfigModel{
+		Owner:                          types.StringValue("test-org"),
+		Name:                           types.StringValue("Test Policy"),
+		EnableActionPolicy:             types.BoolValue(true),
+		AllowedActions:                 types.MapNull(types.StringType),
+		EnableRunsOnPolicy:             types.BoolValue(false),
+		DisallowedRunnerLabels:         types.SetNull(types.StringType),
+		EnableSecretsPolicy:            types.BoolValue(false),
+		EnableCompromisedActionsPolicy: types.BoolValue(false),
+		RequirePinnedActions:           types.BoolValue(true),
+		PinnedActionsExemptions:        types.SetNull(types.StringType),
+		IsDryRun:                       types.BoolValue(false),
+		ExemptedUsers:                  types.SetNull(types.StringType),
+	}
+
+	createRequest := stepsecurityapi.CreateRunPolicyRequest{
+		PolicyConfig: stepsecurityapi.RunPolicyConfig{
+			RequirePinnedActions: policyConfig.RequirePinnedActions.ValueBool(),
+		},
+	}
+
+	if !policyConfig.PinnedActionsExemptions.IsNull() {
+		t.Fatal("expected PinnedActionsExemptions to be null")
+	}
+
+	assert.True(t, createRequest.PolicyConfig.RequirePinnedActions)
+	assert.Nil(t, createRequest.PolicyConfig.PinnedActionsExemptions)
 }
 
 func testAccGithubRunPolicyResourceConfig(owner, name string) string {

--- a/internal/provider/resource_github_run_policy_test.go
+++ b/internal/provider/resource_github_run_policy_test.go
@@ -48,12 +48,12 @@ func TestAccGithubRunPolicyResource(t *testing.T) {
 			},
 			// Update with pinned actions and Read testing
 			{
-				Config: testAccGithubRunPolicyResourceConfigWithPinning("test-org", "Pinned Actions Policy"),
+				Config: testAccGithubRunPolicyResourceConfigWithPinning("test-org", "Allowed Actions Policy - Pinned Actions Enforcement"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "name", "Pinned Actions Policy"),
+					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "name", "Allowed Actions Policy - Pinned Actions Enforcement"),
 					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.enable_action_policy", "true"),
 					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.require_pinned_actions", "true"),
-					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.pinned_actions_exemptions.#", "1"),
+					resource.TestCheckResourceAttr("stepsecurity_github_run_policy.test", "policy_config.actions_to_exempt_while_pinning.#", "1"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -245,7 +245,7 @@ func TestGithubRunPolicyResource_PinnedActionsRequestSerialization(t *testing.T)
 }
 
 func TestGithubRunPolicyResource_PinnedActionsRequestSerialization_NullExemptions(t *testing.T) {
-	// Verify that when pinned_actions_exemptions is null, the API request
+	// Verify that when actions_to_exempt_while_pinning is null, the API request
 	// field remains nil (not an empty slice).
 	policyConfig := policyConfigModel{
 		Owner:                          types.StringValue("test-org"),
@@ -307,7 +307,7 @@ resource "stepsecurity_github_run_policy" "test" {
     name                      = %[2]q
     enable_action_policy      = true
     require_pinned_actions    = true
-    pinned_actions_exemptions = ["actions/*"]
+    actions_to_exempt_while_pinning = ["actions/*"]
     allowed_actions = {
       "actions/checkout" = "allow"
     }

--- a/internal/stepsecurity-api/gh-run-policies.go
+++ b/internal/stepsecurity-api/gh-run-policies.go
@@ -31,6 +31,8 @@ type RunPolicyConfig struct {
 	DisallowedRunnerLabels         map[string]struct{} `json:"disallowed_runner_labels,omitempty"`
 	EnableSecretsPolicy            bool                `json:"enable_secrets_policy,omitempty"`
 	EnableCompromisedActionsPolicy bool                `json:"enable_compromised_actions_policy,omitempty"`
+	RequirePinnedActions           bool                `json:"require_pinned_actions,omitempty"`
+	PinnedActionsExemptions        []string            `json:"pinned_actions_exemptions,omitempty"`
 	IsDryRun                       bool                `json:"is_dry_run,omitempty"`
 	ExemptedUsers                  []string            `json:"exempted_users,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds `require_pinned_actions` (bool) and `pinned_actions_exemptions` (set of strings) to the `policy_config` block in the `stepsecurity_github_run_policy` resource and `stepsecurity_github_run_policies` datasource
- a sub-feature of the allowed actions policy that enforces all GitHub Actions are pinned to full-length commit SHAs
- No provider-side validation on the dependency with `enable_action_policy`; the API is the source of truth

## Changes

- **API structs** (`gh-run-policies.go`): Added `RequirePinnedActions` and `PinnedActionsExemptions` to `RunPolicyConfig`
- **Resource** (`resource_github_run_policy.go`): Schema, Create, Update, and `updateModelFromAPI` updated for both fields
- **Datasource** (`datasource_github_run_policies.go`): Schema and Read updated across all three type-map locations
- **Tests**: Unit tests for API-to-model round trip (with and without nil exemptions), datasource type-map sync test, acceptance test step with pinning config
- **Docs & examples**: New pinned actions examples (standard + dry-run), updated schema docs

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` all pass
- [ ] `TF_ACC=1 go test ./... -run TestAcc` (requires live API credentials)