### PR TITLE
fix: sort lists derived from map iteration for deterministic plan output

### DIFF
--- a/internal/stepsecurity-api/gh-policy-driven-prs.go
+++ b/internal/stepsecurity-api/gh-policy-driven-prs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -402,17 +403,19 @@ func (c *APIClient) GetPolicyDrivenPRPolicy(ctx context.Context, owner string, r
 	enabledSecureDocker := selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubIssue ||
 		selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubPr
 
-	// Extract actions to replace
+	// Extract actions to replace (sorted for deterministic ordering)
 	actionsToReplace := []string{}
 	for action := range selectedConfig.ControlSettings.ActionsToReplace {
 		actionsToReplace = append(actionsToReplace, action)
 	}
+	sort.Strings(actionsToReplace)
 
-	// Convert update_precommit_file from map to array
+	// Convert update_precommit_file from map to array (sorted for deterministic ordering)
 	updatePrecommitFiles := []string{}
 	for file := range selectedConfig.ControlSettings.UpdatePrecommitFile {
 		updatePrecommitFiles = append(updatePrecommitFiles, file)
 	}
+	sort.Strings(updatePrecommitFiles)
 
 	// Set policy fields - repos will be set by the caller based on state
 	policy.UseRepoLevelConfig = !isOrgLevel
@@ -619,17 +622,19 @@ func (c *APIClient) DiscoverPolicyDrivenPRConfig(ctx context.Context, owner stri
 	enabledSecureDocker := selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubIssue ||
 		selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubPr
 
-	// Extract actions to replace
+	// Extract actions to replace (sorted for deterministic ordering)
 	actionsToReplace := []string{}
 	for action := range selectedConfig.ControlSettings.ActionsToReplace {
 		actionsToReplace = append(actionsToReplace, action)
 	}
+	sort.Strings(actionsToReplace)
 
-	// Convert update_precommit_file from map to array
+	// Convert update_precommit_file from map to array (sorted for deterministic ordering)
 	updatePrecommitFiles := []string{}
 	for file := range selectedConfig.ControlSettings.UpdatePrecommitFile {
 		updatePrecommitFiles = append(updatePrecommitFiles, file)
 	}
+	sort.Strings(updatePrecommitFiles)
 
 	policy.SelectedRepos = selectedRepos
 	policy.UseRepoLevelConfig = !useOrgLevel

--- a/internal/stepsecurity-api/gh-policy-driven-prs.go
+++ b/internal/stepsecurity-api/gh-policy-driven-prs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -416,17 +417,19 @@ func (c *APIClient) GetPolicyDrivenPRPolicy(ctx context.Context, owner string, r
 	enabledSecureDocker := selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubIssue ||
 		selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubPr
 
-	// Extract actions to replace
+	// Extract actions to replace (sorted for deterministic ordering)
 	actionsToReplace := []string{}
 	for action := range selectedConfig.ControlSettings.ActionsToReplace {
 		actionsToReplace = append(actionsToReplace, action)
 	}
+	sort.Strings(actionsToReplace)
 
-	// Convert update_precommit_file from map to array
+	// Convert update_precommit_file from map to array (sorted for deterministic ordering)
 	updatePrecommitFiles := []string{}
 	for file := range selectedConfig.ControlSettings.UpdatePrecommitFile {
 		updatePrecommitFiles = append(updatePrecommitFiles, file)
 	}
+	sort.Strings(updatePrecommitFiles)
 
 	// Set policy fields - repos will be set by the caller based on state
 	policy.UseRepoLevelConfig = !isOrgLevel
@@ -635,17 +638,19 @@ func (c *APIClient) DiscoverPolicyDrivenPRConfig(ctx context.Context, owner stri
 	enabledSecureDocker := selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubIssue ||
 		selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubPr
 
-	// Extract actions to replace
+	// Extract actions to replace (sorted for deterministic ordering)
 	actionsToReplace := []string{}
 	for action := range selectedConfig.ControlSettings.ActionsToReplace {
 		actionsToReplace = append(actionsToReplace, action)
 	}
+	sort.Strings(actionsToReplace)
 
-	// Convert update_precommit_file from map to array
+	// Convert update_precommit_file from map to array (sorted for deterministic ordering)
 	updatePrecommitFiles := []string{}
 	for file := range selectedConfig.ControlSettings.UpdatePrecommitFile {
 		updatePrecommitFiles = append(updatePrecommitFiles, file)
 	}
+	sort.Strings(updatePrecommitFiles)
 
 	policy.SelectedRepos = selectedRepos
 	policy.UseRepoLevelConfig = !useOrgLevel


### PR DESCRIPTION
## Summary
- Sort `actions_to_replace_with_step_security_actions` and `update_precommit_file` after building them from Go map iteration in both `GetPolicyDrivenPRPolicy()` and `DiscoverPolicyDrivenPRConfig()`
- Eliminates spurious `terraform plan` diffs caused by non-deterministic Go map iteration order

## Problem
The StepSecurity API represents `actions_to_replace` as `map[string]string` and `update_precommit_file` as `map[string]bool`. When converting these to `[]string` slices for the Terraform state, the provider iterates over the maps with `for key := range m`. Per the [Go specification](https://go.dev/ref/spec#For_range), map iteration order is not guaranteed, so successive reads produce slices in random order.

Since Terraform compares list attributes by position (not as sets), this causes every `terraform plan` to show in-place updates even when nothing has actually changed:

```
~ actions_to_replace_with_step_security_actions = [
    - "docker/setup-buildx-action",
      "google-github-actions/auth",
    + "docker/setup-buildx-action",
      ...
  ]
```

## Fix
Added `sort.Strings()` after each map-to-slice conversion in:
- `GetPolicyDrivenPRPolicy()` — `actionsToReplace` and `updatePrecommitFiles`
- `DiscoverPolicyDrivenPRConfig()` — `actionsToReplace` and `updatePrecommitFiles`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes
- [ ] Manual verification: `terraform plan` shows no changes after `terraform apply` for resources with `actions_to_replace_with_step_security_actions` and `update_precommit_file`