### PR TITLE
refactor(github-checks): change controls attribute from slice to types.List

### DIFF
--- a/internal/provider/resource_github_checks.go
+++ b/internal/provider/resource_github_checks.go
@@ -259,12 +259,18 @@ func (r *githubChecksResource) ValidateConfig(ctx context.Context, req resource.
 
 	hasRequired := false
 	hasOptional := false
+	// controlsIndeterminate is true whenever we could not fully evaluate every control's
+	// type/enable state (the whole list is unknown, or an individual control's fields are
+	// unknown). In that case hasRequired/hasOptional cannot be trusted, so cross-checks that
+	// depend on them must be skipped until a later plan when the values are known.
+	controlsIndeterminate := false
 
 	if config.Controls.IsUnknown() {
 		// The whole controls list is unknown (e.g., it is derived from a value that
 		// isn't known until apply, such as a for_each over an unresolved collection).
 		// Skip control-level validation until the value is known; it will be
 		// re-validated on a subsequent plan.
+		controlsIndeterminate = true
 	} else if config.Controls.IsNull() || len(config.Controls.Elements()) == 0 {
 		resp.Diagnostics.AddError(
 			"Controls are required",
@@ -281,6 +287,7 @@ func (r *githubChecksResource) ValidateConfig(ctx context.Context, req resource.
 		for _, control := range controls {
 			// Skip validation if control attributes are unknown (e.g., when using for_each or count)
 			if control.Control.IsUnknown() || control.Type.IsUnknown() || control.Enable.IsUnknown() {
+				controlsIndeterminate = true
 				continue
 			}
 
@@ -332,14 +339,14 @@ func (r *githubChecksResource) ValidateConfig(ctx context.Context, req resource.
 		}
 	}
 
-	if config.RequiredChecks != nil && len(config.RequiredChecks.Repos.Elements()) != 0 && !hasRequired {
+	if !controlsIndeterminate && config.RequiredChecks != nil && len(config.RequiredChecks.Repos.Elements()) != 0 && !hasRequired {
 		resp.Diagnostics.AddError(
 			"can't provide repos for required checks without enabling any control for required checks",
 			"No control of type 'required' is enabled to apply to the repos",
 		)
 	}
 
-	if config.OptionalChecks != nil && len(config.OptionalChecks.Repos.Elements()) != 0 && !hasOptional {
+	if !controlsIndeterminate && config.OptionalChecks != nil && len(config.OptionalChecks.Repos.Elements()) != 0 && !hasOptional {
 		resp.Diagnostics.AddError(
 			"can't provide repos for optional checks without enabling any control for optional checks",
 			"No control of type 'optional' is enabled to apply to the repos",

--- a/internal/provider/resource_github_checks.go
+++ b/internal/provider/resource_github_checks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -188,7 +189,7 @@ func (r *githubChecksResource) ImportState(ctx context.Context, req resource.Imp
 
 type githubChecksModel struct {
 	Owner             types.String  `tfsdk:"owner"`
-	Controls          []control     `tfsdk:"controls"`
+	Controls          types.List    `tfsdk:"controls"`
 	RequiredChecks    *checksConfig `tfsdk:"required_checks"`
 	OptionalChecks    *checksConfig `tfsdk:"optional_checks"`
 	BaselineCheck     *checksConfig `tfsdk:"baseline_check"`
@@ -207,6 +208,40 @@ type control struct {
 	Settings types.Object `tfsdk:"settings"`
 }
 
+// controlSettingsAttrTypes returns the attribute types for a control's "settings" object.
+func controlSettingsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"cool_down_period":                     types.Int64Type,
+		"packages_to_exempt_in_cooldown_check": types.ListType{ElemType: types.StringType},
+	}
+}
+
+// controlObjectType returns the object type of a single element of the "controls" list.
+// The "controls" attribute is bound to types.List (rather than a plain Go slice) so that
+// the framework can represent an unknown list value (e.g. when it is derived from a value
+// that is not known until apply); a plain []control cannot represent "unknown".
+func controlObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"control": types.StringType,
+			"enable":  types.BoolType,
+			"type":    types.StringType,
+			"settings": types.ObjectType{
+				AttrTypes: controlSettingsAttrTypes(),
+			},
+		},
+	}
+}
+
+// diagsToError flattens error diagnostics into a single error.
+func diagsToError(diags diag.Diagnostics) error {
+	msgs := make([]string, 0, len(diags))
+	for _, d := range diags.Errors() {
+		msgs = append(msgs, fmt.Sprintf("%s: %s", d.Summary(), d.Detail()))
+	}
+	return fmt.Errorf("%s", strings.Join(msgs, "; "))
+}
+
 func (r *githubChecksResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var config githubChecksModel
 	diags := req.Config.Get(ctx, &config)
@@ -222,66 +257,79 @@ func (r *githubChecksResource) ValidateConfig(ctx context.Context, req resource.
 		)
 	}
 
-	if len(config.Controls) == 0 {
+	hasRequired := false
+	hasOptional := false
+
+	if config.Controls.IsUnknown() {
+		// The whole controls list is unknown (e.g., it is derived from a value that
+		// isn't known until apply, such as a for_each over an unresolved collection).
+		// Skip control-level validation until the value is known; it will be
+		// re-validated on a subsequent plan.
+	} else if config.Controls.IsNull() || len(config.Controls.Elements()) == 0 {
 		resp.Diagnostics.AddError(
 			"Controls are required",
 			"Controls are required to create a GitHub Checks resource",
 		)
-	}
-
-	hasRequired := false
-	hasOptional := false
-	for _, control := range config.Controls {
-		// Skip validation if control attributes are unknown (e.g., when using for_each or count)
-		if control.Control.IsUnknown() || control.Type.IsUnknown() || control.Enable.IsUnknown() {
-			continue
+	} else {
+		var controls []control
+		diags = config.Controls.ElementsAs(ctx, &controls, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 
-		if _, ok := stepsecurityapi.AvailableControls[control.Control.ValueString()]; !ok {
-			resp.Diagnostics.AddError(
-				"Invalid control provided",
-				"only the following controls are accepted to configure: "+strings.Join(stepsecurityapi.GetAvailableControls(), ", \n"),
-			)
-		}
+		for _, control := range controls {
+			// Skip validation if control attributes are unknown (e.g., when using for_each or count)
+			if control.Control.IsUnknown() || control.Type.IsUnknown() || control.Enable.IsUnknown() {
+				continue
+			}
 
-		if control.Type.ValueString() == "required" && control.Enable.ValueBool() {
-			hasRequired = true
-		}
-		if control.Type.ValueString() == "optional" && control.Enable.ValueBool() {
-			hasOptional = true
-		}
-		if control.Type.ValueString() != "required" && control.Type.ValueString() != "optional" {
-			resp.Diagnostics.AddError(
-				"Type can only be 'required' or 'optional'",
-				"Type can only be 'required' or 'optional'",
-			)
-		}
+			if _, ok := stepsecurityapi.AvailableControls[control.Control.ValueString()]; !ok {
+				resp.Diagnostics.AddError(
+					"Invalid control provided",
+					"only the following controls are accepted to configure: "+strings.Join(stepsecurityapi.GetAvailableControls(), ", \n"),
+				)
+			}
 
-		isCooldownControl := control.Control.ValueString() == "NPM Package Cooldown" ||
-			control.Control.ValueString() == "PyPI Package Cooldown" ||
-			control.Control.ValueString() == "Maven Package Cooldown"
-		if !isCooldownControl && !control.Settings.IsNull() && !control.Settings.IsUnknown() {
-			resp.Diagnostics.AddError(
-				"can't provide settings",
-				"can't provide settings for control "+control.Control.ValueString(),
-			)
-		}
+			if control.Type.ValueString() == "required" && control.Enable.ValueBool() {
+				hasRequired = true
+			}
+			if control.Type.ValueString() == "optional" && control.Enable.ValueBool() {
+				hasOptional = true
+			}
+			if control.Type.ValueString() != "required" && control.Type.ValueString() != "optional" {
+				resp.Diagnostics.AddError(
+					"Type can only be 'required' or 'optional'",
+					"Type can only be 'required' or 'optional'",
+				)
+			}
 
-		if isCooldownControl && !control.Settings.IsNull() && !control.Settings.IsUnknown() {
-			// Extract cooldown period from the object
-			if cooldownAttr := control.Settings.Attributes()["cool_down_period"]; cooldownAttr != nil {
-				if cooldownValue, ok := cooldownAttr.(types.Int64); ok {
-					period := cooldownValue.ValueInt64()
-					if period != 0 && (period < 1 || period > 30) {
-						resp.Diagnostics.AddError(
-							"cool_down_period should be between 1 and 30",
-							"cool_down_period should be between 1 and 30 for control "+control.Control.ValueString(),
-						)
+			isCooldownControl := control.Control.ValueString() == "NPM Package Cooldown" ||
+				control.Control.ValueString() == "PyPI Package Cooldown" ||
+				control.Control.ValueString() == "Maven Package Cooldown"
+			if !isCooldownControl && !control.Settings.IsNull() && !control.Settings.IsUnknown() {
+				resp.Diagnostics.AddError(
+					"can't provide settings",
+					"can't provide settings for control "+control.Control.ValueString(),
+				)
+			}
+
+			if isCooldownControl && !control.Settings.IsNull() && !control.Settings.IsUnknown() {
+				// Extract cooldown period from the object
+				if cooldownAttr := control.Settings.Attributes()["cool_down_period"]; cooldownAttr != nil {
+					if cooldownValue, ok := cooldownAttr.(types.Int64); ok {
+						period := cooldownValue.ValueInt64()
+						if period != 0 && (period < 1 || period > 30) {
+							resp.Diagnostics.AddError(
+								"cool_down_period should be between 1 and 30",
+								"cool_down_period should be between 1 and 30 for control "+control.Control.ValueString(),
+							)
+						}
 					}
 				}
 			}
-		}
 
+		}
 	}
 
 	if config.RequiredChecks != nil && len(config.RequiredChecks.Repos.Elements()) != 0 && !hasRequired {
@@ -386,9 +434,20 @@ func (r *githubChecksResource) ModifyPlan(ctx context.Context, req resource.Modi
 		return
 	}
 
+	if plan.Controls.IsUnknown() || plan.Controls.IsNull() {
+		return
+	}
+
+	var controls []control
+	diags = plan.Controls.ElementsAs(ctx, &controls, false)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	modified := false
 
-	for ind, control := range plan.Controls {
+	for ind, control := range controls {
 
 		if (control.Control.ValueString() == "NPM Package Cooldown" ||
 			control.Control.ValueString() == "PyPI Package Cooldown" ||
@@ -398,20 +457,21 @@ func (r *githubChecksResource) ModifyPlan(ctx context.Context, req resource.Modi
 				"cool_down_period":                     types.Int64Value(2),
 				"packages_to_exempt_in_cooldown_check": types.ListNull(types.StringType),
 			}
-			settingsType := types.ObjectType{
-				AttrTypes: map[string]attr.Type{
-					"cool_down_period":                     types.Int64Type,
-					"packages_to_exempt_in_cooldown_check": types.ListType{ElemType: types.StringType},
-				},
-			}
-			control.Settings, _ = types.ObjectValue(settingsType.AttrTypes, settingsMap)
-			plan.Controls[ind] = control
+			control.Settings, _ = types.ObjectValue(controlSettingsAttrTypes(), settingsMap)
+			controls[ind] = control
 			modified = true
 		}
 	}
 
 	// Set the plan back (either because it was modified )
 	if modified {
+		newControls, listDiags := types.ListValueFrom(ctx, controlObjectType(), controls)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Controls = newControls
+
 		diags = resp.Plan.Set(ctx, plan)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
@@ -430,7 +490,7 @@ func (r *githubChecksResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	createRequest, err := r.convertToCreateRequest(plan)
+	createRequest, err := r.convertToCreateRequest(ctx, plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating GitHub Checks",
@@ -448,7 +508,7 @@ func (r *githubChecksResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	state := r.convertToState(plan.Owner.ValueString(), *createRequest)
+	state := r.convertToState(ctx, plan.Owner.ValueString(), *createRequest)
 	state.Owner = types.StringValue(plan.Owner.ValueString())
 	r.updateStateListsWithOrderFromPlan(ctx, plan, &state)
 
@@ -478,7 +538,7 @@ func (r *githubChecksResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	newState := r.convertToState(state.Owner.ValueString(), config)
+	newState := r.convertToState(ctx, state.Owner.ValueString(), config)
 	r.updateStateListsWithOrderFromPlan(ctx, state, &newState)
 
 	diags = resp.State.Set(ctx, newState)
@@ -497,7 +557,7 @@ func (r *githubChecksResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	updateRequest, err := r.convertToCreateRequest(plan)
+	updateRequest, err := r.convertToCreateRequest(ctx, plan)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating GitHub Checks",
@@ -515,7 +575,7 @@ func (r *githubChecksResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	state := r.convertToState(plan.Owner.ValueString(), *updateRequest)
+	state := r.convertToState(ctx, plan.Owner.ValueString(), *updateRequest)
 	state.Owner = types.StringValue(plan.Owner.ValueString())
 	r.updateStateListsWithOrderFromPlan(ctx, plan, &state)
 
@@ -555,10 +615,19 @@ func (r *githubChecksResource) Delete(ctx context.Context, req resource.DeleteRe
 
 }
 
-func (r *githubChecksResource) convertToCreateRequest(plan githubChecksModel) (*stepsecurityapi.GitHubPRChecksConfig, error) {
+func (r *githubChecksResource) convertToCreateRequest(ctx context.Context, plan githubChecksModel) (*stepsecurityapi.GitHubPRChecksConfig, error) {
 	prChecksConfig := stepsecurityapi.GitHubPRChecksConfig{}
 	prChecksConfig.Checks = make(map[string]stepsecurityapi.CheckConfig)
-	for _, control := range plan.Controls {
+
+	var controls []control
+	if !plan.Controls.IsNull() && !plan.Controls.IsUnknown() {
+		diags := plan.Controls.ElementsAs(ctx, &controls, false)
+		if diags.HasError() {
+			return nil, diagsToError(diags)
+		}
+	}
+
+	for _, control := range controls {
 		controlName := control.Control.ValueString()
 		checkConfig := stepsecurityapi.CheckConfig{
 			Enabled: control.Enable.ValueBool(),
@@ -746,7 +815,7 @@ func (r *githubChecksResource) convertToCreateRequest(plan githubChecksModel) (*
 	return &prChecksConfig, nil
 }
 
-func (r *githubChecksResource) convertToState(owner string, config stepsecurityapi.GitHubPRChecksConfig) githubChecksModel {
+func (r *githubChecksResource) convertToState(ctx context.Context, owner string, config stepsecurityapi.GitHubPRChecksConfig) githubChecksModel {
 	model := githubChecksModel{}
 	model.Owner = types.StringValue(owner)
 	if config.CustomDescription != "" {
@@ -755,8 +824,8 @@ func (r *githubChecksResource) convertToState(owner string, config stepsecuritya
 		model.CustomDescription = types.StringNull()
 	}
 
-	// Initialize Controls as empty slice instead of nil
-	model.Controls = []control{}
+	// Initialize controls as an empty slice instead of nil
+	controls := []control{}
 
 	// Don't initialize pointer fields yet - only initialize them if needed
 
@@ -820,29 +889,22 @@ func (r *githubChecksResource) convertToState(owner string, config stepsecuritya
 				"cool_down_period":                     cooldownPeriod,
 				"packages_to_exempt_in_cooldown_check": packagesList,
 			}
-			settingsType := types.ObjectType{
-				AttrTypes: map[string]attr.Type{
-					"cool_down_period":                     types.Int64Type,
-					"packages_to_exempt_in_cooldown_check": types.ListType{ElemType: types.StringType},
-				},
-			}
-			c.Settings, _ = types.ObjectValue(settingsType.AttrTypes, settingsMap)
+			c.Settings, _ = types.ObjectValue(controlSettingsAttrTypes(), settingsMap)
 		} else {
 			// For non-NPM controls or controls without settings, set to null
-			c.Settings = types.ObjectNull(map[string]attr.Type{
-				"cool_down_period":                     types.Int64Type,
-				"packages_to_exempt_in_cooldown_check": types.ListType{ElemType: types.StringType},
-			})
+			c.Settings = types.ObjectNull(controlSettingsAttrTypes())
 		}
 
-		model.Controls = append(model.Controls, c)
+		controls = append(controls, c)
 	}
 
 	// Sort controls by name to ensure deterministic order
 	// This prevents Terraform from detecting changes due to random map iteration order
-	sort.Slice(model.Controls, func(i, j int) bool {
-		return model.Controls[i].Control.ValueString() < model.Controls[j].Control.ValueString()
+	sort.Slice(controls, func(i, j int) bool {
+		return controls[i].Control.ValueString() < controls[j].Control.ValueString()
 	})
+
+	model.Controls, _ = types.ListValueFrom(ctx, controlObjectType(), controls)
 
 	// Flags for applying checks to all repos
 	isBaselineAll := config.EnableBaselineCheckForAllNewRepos != nil && *config.EnableBaselineCheckForAllNewRepos
@@ -904,7 +966,7 @@ func (r *githubChecksResource) convertToState(owner string, config stepsecuritya
 	hasRequiredControls := false
 	hasOptionalControls := false
 
-	for _, control := range model.Controls {
+	for _, control := range controls {
 		if control.Enable.ValueBool() {
 			switch control.Type.ValueString() {
 			case "required":
@@ -1020,15 +1082,27 @@ func (r *githubChecksResource) updateStateListsWithOrderFromPlan(ctx context.Con
 	}
 
 	// preserve order of controls
+	if plan.Controls.IsUnknown() || plan.Controls.IsNull() || state.Controls.IsUnknown() || state.Controls.IsNull() {
+		return
+	}
+
+	var planControls, stateControls []control
+	if diags := plan.Controls.ElementsAs(ctx, &planControls, false); diags.HasError() {
+		return
+	}
+	if diags := state.Controls.ElementsAs(ctx, &stateControls, false); diags.HasError() {
+		return
+	}
+
 	// Create a map of controls from state for efficient lookup
 	controls2Map := make(map[string]control)
-	for _, ctrl := range state.Controls {
+	for _, ctrl := range stateControls {
 		controls2Map[ctrl.Control.ValueString()] = ctrl
 	}
 
 	// Reorder state controls to match plan order
-	orderedControls := make([]control, 0, len(plan.Controls))
-	for _, ctrl := range plan.Controls {
+	orderedControls := make([]control, 0, len(planControls))
+	for _, ctrl := range planControls {
 		if _, exists := controls2Map[ctrl.Control.ValueString()]; !exists {
 			tflog.Info(ctx, "Control not found in state", map[string]any{
 				"control": ctrl.Control.ValueString(),
@@ -1037,7 +1111,7 @@ func (r *githubChecksResource) updateStateListsWithOrderFromPlan(ctx context.Con
 		}
 		orderedControls = append(orderedControls, controls2Map[ctrl.Control.ValueString()])
 	}
-	state.Controls = orderedControls
+	state.Controls, _ = types.ListValueFrom(ctx, controlObjectType(), orderedControls)
 
 }
 

--- a/internal/provider/resource_github_checks_test.go
+++ b/internal/provider/resource_github_checks_test.go
@@ -671,6 +671,59 @@ func TestGithubChecksResource_ValidateConfig_UnknownControlsList(t *testing.T) {
 	assert.False(t, validateResp.Diagnostics.HasError(), "unexpected diagnostics: %v", validateResp.Diagnostics)
 }
 
+// TestGithubChecksResource_ValidateConfig_UnknownControlsListWithKnownRepos is a regression
+// test for a false positive introduced while fixing the crash covered by
+// TestGithubChecksResource_ValidateConfig_UnknownControlsList above: when "controls" is
+// unknown but required_checks/baseline_check repos are known literals (e.g. "*", as in a
+// customer config using terraform_data to make controls unknown on the first plan),
+// ValidateConfig must not error with "can't provide repos for required checks without
+// enabling any control for required checks". hasRequired/hasOptional cannot be determined
+// while controls is unknown, so those cross-checks must be skipped until a later plan when
+// controls becomes known.
+func TestGithubChecksResource_ValidateConfig_UnknownControlsListWithKnownRepos(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := &githubChecksResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	starList, diags := types.ListValue(types.StringType, []attr.Value{types.StringValue("*")})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics building repos list: %v", diags)
+	}
+
+	model := githubChecksModel{
+		Owner:    types.StringValue(testOwner),
+		Controls: types.ListUnknown(controlObjectType()),
+		RequiredChecks: &checksConfig{
+			Repos:     starList,
+			OmitRepos: types.ListNull(types.StringType),
+		},
+		BaselineCheck: &checksConfig{
+			Repos:     starList,
+			OmitRepos: types.ListNull(types.StringType),
+		},
+	}
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	planDiags := plan.Set(ctx, model)
+	if planDiags.HasError() {
+		t.Fatalf("unexpected diagnostics setting plan: %v", planDiags)
+	}
+
+	config := tfsdk.Config{Raw: plan.Raw, Schema: schemaResp.Schema}
+	validateResp := &resource.ValidateConfigResponse{}
+
+	r.ValidateConfig(ctx, resource.ValidateConfigRequest{Config: config}, validateResp)
+
+	assert.False(t, validateResp.Diagnostics.HasError(), "unexpected diagnostics (false positive on unknown controls + known repos): %v", validateResp.Diagnostics)
+}
+
 func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/resource_github_checks_test.go
+++ b/internal/provider/resource_github_checks_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	res "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,29 @@ func createNullSettingsObject() types.Object {
 		"cool_down_period":                     types.Int64Type,
 		"packages_to_exempt_in_cooldown_check": types.ListType{ElemType: types.StringType},
 	})
+}
+
+// mustControlsList converts a []control slice into the types.List value that the
+// "controls" attribute is now bound to.
+func mustControlsList(controls []control) types.List {
+	list, diags := types.ListValueFrom(context.Background(), controlObjectType(), controls)
+	if diags.HasError() {
+		panic(diagsToError(diags))
+	}
+	return list
+}
+
+// controlsListToSlice decodes a "controls" types.List back into a []control slice for assertions.
+func controlsListToSlice(list types.List) []control {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	var controls []control
+	diags := list.ElementsAs(context.Background(), &controls, false)
+	if diags.HasError() {
+		panic(diagsToError(diags))
+	}
+	return controls
 }
 
 func TestAccGithubChecksResource(t *testing.T) {
@@ -349,14 +373,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "valid_config",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -371,14 +395,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "empty_owner",
 			config: githubChecksModel{
 				Owner: types.StringValue(""),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			expectedError: true,
 			errorContains: "Owner is required",
@@ -387,7 +411,7 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "empty_controls",
 			config: githubChecksModel{
 				Owner:    types.StringValue(testOwner),
-				Controls: []control{},
+				Controls: mustControlsList([]control{}),
 			},
 			expectedError: true,
 			errorContains: "Controls are required",
@@ -396,14 +420,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "invalid_control",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Invalid Control"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			expectedError: true,
 			errorContains: "Invalid control provided",
@@ -412,14 +436,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "invalid_type",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("invalid"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			expectedError: true,
 			errorContains: "Type can only be 'required' or 'optional'",
@@ -428,14 +452,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "cooldown_period_out_of_range",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(50); return &v }(), nil),
 					},
-				},
+				}),
 			},
 			expectedError: true,
 			errorContains: "cool_down_period should be between 1 and 30",
@@ -444,14 +468,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "valid_pypi_cooldown",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(5); return &v }(), nil),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -466,14 +490,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "valid_pypi_compromised_updates",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Compromised Updates"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -488,14 +512,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "pypi_cooldown_period_out_of_range",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(50); return &v }(), nil),
 					},
-				},
+				}),
 			},
 			expectedError: true,
 			errorContains: "cool_down_period should be between 1 and 30",
@@ -504,14 +528,14 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 			name: "settings_provided_for_pypi_compromised_updates",
 			config: githubChecksModel{
 				Owner: types.StringValue(testOwner),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Compromised Updates"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(3); return &v }(), nil),
 					},
-				},
+				}),
 			},
 			expectedError: true,
 			errorContains: "can't provide settings",
@@ -534,14 +558,16 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 				)
 			}
 
-			if len(tc.config.Controls) == 0 {
+			configControls := controlsListToSlice(tc.config.Controls)
+
+			if len(configControls) == 0 {
 				mockResp.Diagnostics.AddError(
 					"Controls are required",
 					"Controls are required to create a GitHub Checks resource",
 				)
 			}
 
-			for _, control := range tc.config.Controls {
+			for _, control := range configControls {
 				if _, ok := stepsecurityapi.AvailableControls[control.Control.ValueString()]; !ok {
 					mockResp.Diagnostics.AddError(
 						"Invalid control provided",
@@ -605,6 +631,46 @@ func TestGithubChecksResource_ValidateConfig(t *testing.T) {
 	}
 }
 
+// TestGithubChecksResource_ValidateConfig_UnknownControlsList is a regression test for a
+// customer-reported crash: when the whole "controls" list is unknown at plan time (e.g. it
+// is derived from a for_each/local referencing a value that isn't known until apply), the
+// framework used to fail to bind it into a plain []control field with:
+//
+//	"Received unknown value, however the target type cannot handle unknown values."
+//
+// ValidateConfig must handle this gracefully instead of erroring.
+func TestGithubChecksResource_ValidateConfig_UnknownControlsList(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := &githubChecksResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	model := githubChecksModel{
+		Owner:    types.StringValue(testOwner),
+		Controls: types.ListUnknown(controlObjectType()),
+	}
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	diags := plan.Set(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics setting plan: %v", diags)
+	}
+
+	config := tfsdk.Config{Raw: plan.Raw, Schema: schemaResp.Schema}
+	validateResp := &resource.ValidateConfigResponse{}
+
+	assert.NotPanics(t, func() {
+		r.ValidateConfig(ctx, resource.ValidateConfigRequest{Config: config}, validateResp)
+	})
+	assert.False(t, validateResp.Diagnostics.HasError(), "unexpected diagnostics: %v", validateResp.Diagnostics)
+}
+
 func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 	t.Parallel()
 
@@ -619,14 +685,14 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "basic_config_with_npm_cooldown",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(5); return &v }(), nil),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -658,14 +724,14 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "package_exemptions",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(3); return &v }(), []string{"lodash", "express"}),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -698,7 +764,7 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "multiple_controls_and_repos",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
@@ -711,7 +777,7 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 						Type:     types.StringValue("optional"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -774,14 +840,14 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "baseline_checks_enabled",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -818,14 +884,14 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "basic_config_with_pypi_cooldown",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(3); return &v }(), []string{"my-internal-pkg"}),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -858,14 +924,14 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "pypi_compromised_updates",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Compromised Updates"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -895,14 +961,14 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			name: "omit_repos_configuration",
 			input: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PWN Request"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("optional"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				OptionalChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -954,7 +1020,7 @@ func TestGithubChecksResource_ConvertToCreateRequest(t *testing.T) {
 			t.Parallel()
 
 			r := &githubChecksResource{}
-			result, err := r.convertToCreateRequest(tc.input)
+			result, err := r.convertToCreateRequest(context.Background(), tc.input)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -1004,14 +1070,14 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			},
 			expected: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(7); return &v }(), nil),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -1071,7 +1137,7 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			},
 			expected: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
@@ -1090,7 +1156,7 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 						Type:     types.StringValue("optional"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -1141,14 +1207,14 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			},
 			expected: githubChecksModel{
 				Owner: types.StringValue("global-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Compromised Updates"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -1198,14 +1264,14 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			},
 			expected: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Cooldown"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(3); return &v }(), []string{"my-internal-pkg"}),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -1238,14 +1304,14 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			},
 			expected: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PyPI Package Compromised Updates"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 				RequiredChecks: &checksConfig{
 					Repos: func() types.List {
 						elements := []attr.Value{types.StringValue("*")}
@@ -1272,7 +1338,7 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			},
 			expected: githubChecksModel{
 				Owner:          types.StringValue("empty-org"),
-				Controls:       []control{},
+				Controls:       mustControlsList([]control{}),
 				RequiredChecks: nil,
 				OptionalChecks: nil,
 				BaselineCheck:  nil,
@@ -1285,7 +1351,7 @@ func TestGithubChecksResource_ConvertToState(t *testing.T) {
 			t.Parallel()
 
 			r := &githubChecksResource{}
-			got := r.convertToState(tc.owner, tc.input)
+			got := r.convertToState(context.Background(), tc.owner, tc.input)
 
 			// Use Equal to compare the entire result structure
 			assert.Equal(t, tc.expected, got)
@@ -1765,7 +1831,7 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 			name: "controls_same_content_different_order",
 			plan: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
@@ -1778,11 +1844,11 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("optional"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			state: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("PWN Request"),
 						Enable:   types.BoolValue(true),
@@ -1795,11 +1861,11 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			expectedState: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
@@ -1812,14 +1878,14 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("optional"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 		},
 		{
 			name: "controls_with_settings_same_content_different_order",
 			plan: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
@@ -1832,11 +1898,11 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			state: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
@@ -1849,11 +1915,11 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("required"),
 						Settings: createSettingsObject(func() *int64 { v := int64(5); return &v }(), []string{"express", "lodash"}),
 					},
-				},
+				}),
 			},
 			expectedState: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("NPM Package Cooldown"),
 						Enable:   types.BoolValue(true),
@@ -1866,14 +1932,14 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 		},
 		{
 			name: "controls_missing_in_state",
 			plan: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
@@ -1886,29 +1952,29 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 						Type:     types.StringValue("optional"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			state: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 			expectedState: githubChecksModel{
 				Owner: types.StringValue("test-org"),
-				Controls: []control{
+				Controls: mustControlsList([]control{
 					{
 						Control:  types.StringValue("Script Injection"),
 						Enable:   types.BoolValue(true),
 						Type:     types.StringValue("required"),
 						Settings: createNullSettingsObject(),
 					},
-				},
+				}),
 			},
 		},
 		{
@@ -1951,15 +2017,15 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 			name: "empty_controls",
 			plan: githubChecksModel{
 				Owner:    types.StringValue("test-org"),
-				Controls: []control{},
+				Controls: mustControlsList([]control{}),
 			},
 			state: githubChecksModel{
 				Owner:    types.StringValue("test-org"),
-				Controls: []control{},
+				Controls: mustControlsList([]control{}),
 			},
 			expectedState: githubChecksModel{
 				Owner:    types.StringValue("test-org"),
-				Controls: []control{},
+				Controls: mustControlsList([]control{}),
 			},
 		},
 	}
@@ -1977,14 +2043,16 @@ func TestGithubChecksResource_UpdateStateListsWithOrderFromPlan(t *testing.T) {
 			r.updateStateListsWithOrderFromPlan(ctx, tc.plan, &stateCopy)
 
 			// For controls, we need to manually check the order
-			if len(tc.expectedState.Controls) > 0 {
-				assert.Equal(t, len(tc.expectedState.Controls), len(stateCopy.Controls), "Controls length mismatch")
-				for i := range tc.expectedState.Controls {
-					assert.Equal(t, tc.expectedState.Controls[i].Control.ValueString(), stateCopy.Controls[i].Control.ValueString(),
+			expectedControls := controlsListToSlice(tc.expectedState.Controls)
+			actualControls := controlsListToSlice(stateCopy.Controls)
+			if len(expectedControls) > 0 {
+				assert.Equal(t, len(expectedControls), len(actualControls), "Controls length mismatch")
+				for i := range expectedControls {
+					assert.Equal(t, expectedControls[i].Control.ValueString(), actualControls[i].Control.ValueString(),
 						"Control name mismatch at index %d", i)
-					assert.Equal(t, tc.expectedState.Controls[i].Enable.ValueBool(), stateCopy.Controls[i].Enable.ValueBool(),
+					assert.Equal(t, expectedControls[i].Enable.ValueBool(), actualControls[i].Enable.ValueBool(),
 						"Control enable mismatch at index %d", i)
-					assert.Equal(t, tc.expectedState.Controls[i].Type.ValueString(), stateCopy.Controls[i].Type.ValueString(),
+					assert.Equal(t, expectedControls[i].Type.ValueString(), actualControls[i].Type.ValueString(),
 						"Control type mismatch at index %d", i)
 				}
 			}


### PR DESCRIPTION
- Replace the `controls` field in `githubChecksModel` from a plain Go slice (`[]control`) to `types.List` so the framework can represent unknown list values when derived from expressions not known until apply. 
- Add helper functions `controlObjectType()`, `controlSettingsAttrTypes()`, and `diagsToError()` to support the typed list. 