### PR TITLE
fix: sort lists derived from map iteration for deterministic plan output

### DIFF
--- a/internal/stepsecurity-api/gh-policy-driven-prs.go
+++ b/internal/stepsecurity-api/gh-policy-driven-prs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -416,17 +417,19 @@ func (c *APIClient) GetPolicyDrivenPRPolicy(ctx context.Context, owner string, r
 	enabledSecureDocker := selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubIssue ||
 		selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubPr
 
-	// Extract actions to replace
+	// Extract actions to replace (sorted for deterministic ordering)
 	actionsToReplace := []string{}
 	for action := range selectedConfig.ControlSettings.ActionsToReplace {
 		actionsToReplace = append(actionsToReplace, action)
 	}
+	sort.Strings(actionsToReplace)
 
-	// Convert update_precommit_file from map to array
+	// Convert update_precommit_file from map to array (sorted for deterministic ordering)
 	updatePrecommitFiles := []string{}
 	for file := range selectedConfig.ControlSettings.UpdatePrecommitFile {
 		updatePrecommitFiles = append(updatePrecommitFiles, file)
 	}
+	sort.Strings(updatePrecommitFiles)
 
 	// Set policy fields - repos will be set by the caller based on state
 	policy.UseRepoLevelConfig = !isOrgLevel
@@ -635,17 +638,19 @@ func (c *APIClient) DiscoverPolicyDrivenPRConfig(ctx context.Context, owner stri
 	enabledSecureDocker := selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubIssue ||
 		selectedConfig.ControlChecksConfig["SecureDockerFile"].TriggerGithubPr
 
-	// Extract actions to replace
+	// Extract actions to replace (sorted for deterministic ordering)
 	actionsToReplace := []string{}
 	for action := range selectedConfig.ControlSettings.ActionsToReplace {
 		actionsToReplace = append(actionsToReplace, action)
 	}
+	sort.Strings(actionsToReplace)
 
-	// Convert update_precommit_file from map to array
+	// Convert update_precommit_file from map to array (sorted for deterministic ordering)
 	updatePrecommitFiles := []string{}
 	for file := range selectedConfig.ControlSettings.UpdatePrecommitFile {
 		updatePrecommitFiles = append(updatePrecommitFiles, file)
 	}
+	sort.Strings(updatePrecommitFiles)
 
 	policy.SelectedRepos = selectedRepos
 	policy.UseRepoLevelConfig = !useOrgLevel


### PR DESCRIPTION
## Summary

- Sort `actions_to_replace_with_step_security_actions` and `update_precommit_file` after converting the API's Go maps to Terraform list values.
- Eliminate perpetual plan diffs caused by nondeterministic Go map iteration.

Closes #47.

## Provenance and credit

This is a signed, attribution-preserving recreation of #53, which is approved but blocked by the repository's verified-signature requirement.

The implementation and analysis are Ruby Perez's original contribution, submitted in #53 by @vegemitesandwich. Ruby is credited with a `Co-authored-by` trailer and here in the PR provenance. The patch itself is unchanged from #53; it has only been applied to current `main` and committed by @arcaven with a verified hardware-backed signature so the work can move forward.

## Validation

- `go test ./internal/...`
- `go build ./...`
- Diff matches #53: one file, 9 insertions, 4 deletions

_codex-unknown-model-unknown-reasoning on behalf of Michael Pursifull_
