### PR TITLE
fix(policy-driven-pr): preserve configured order for update_precommit_file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,19 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      # The plan-stability tests drive a real Terraform CLI against an httptest fake
+      # backend. Providing the CLI here keeps them from skipping; without it they would
+      # skip rather than have the test harness download one, since hc-install cannot
+      # currently verify HashiCorp's release signature ("openpgp: key expired").
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
       - name: Run go tests
         run: go test -race ./...
-        
+
   docs-check:
     name: Check Documentation
     runs-on: ubuntu-latest

--- a/internal/provider/resource_policy_driven_pr.go
+++ b/internal/provider/resource_policy_driven_pr.go
@@ -1978,7 +1978,78 @@ func (r *policyDrivenPRResource) updatePolicyDrivenPRState(ctx context.Context, 
 	}
 }
 
+// listToStrings extracts a []string from a types.List of strings, skipping any
+// element that is not a known string value.
+func listToStrings(list types.List) []string {
+	out := make([]string, 0, len(list.Elements()))
+	for _, e := range list.Elements() {
+		s, ok := e.(types.String)
+		if !ok || s.IsNull() || s.IsUnknown() {
+			continue
+		}
+		out = append(out, s.ValueString())
+	}
+	return out
+}
+
+// alignListOrder reorders apiList to follow stateList's ordering for the elements the
+// two have in common, appending any element that only the API returned in the order the
+// API returned it.
+//
+// The API stores some of these lists as JSON objects, which unmarshal into Go maps, so
+// the read path has to derive a list from a randomized map range. Sorting that list (see
+// GetPolicyDrivenPRPolicy) makes each read self-consistent but does not match the order
+// the practitioner wrote in their configuration, so a config that is not already sorted
+// gets a permanent reordering diff. Realigning to the prior state's order removes that
+// diff while still surfacing genuine membership changes: an element the API dropped
+// disappears and an element the API added shows up at the end.
+//
+// Returns ok=false when apiList is already in the desired order, so callers can avoid
+// rebuilding the enclosing object for no reason.
+func alignListOrder(ctx context.Context, stateList, apiList types.List) (types.List, bool) {
+	if stateList.IsNull() || stateList.IsUnknown() || apiList.IsNull() || apiList.IsUnknown() {
+		return apiList, false
+	}
+
+	stateElems := listToStrings(stateList)
+	apiElems := listToStrings(apiList)
+	if len(apiElems) == 0 {
+		return apiList, false
+	}
+
+	// Track occurrences rather than mere presence so duplicated elements survive.
+	remaining := make(map[string]int, len(apiElems))
+	for _, e := range apiElems {
+		remaining[e]++
+	}
+
+	aligned := make([]string, 0, len(apiElems))
+	for _, e := range stateElems {
+		if remaining[e] > 0 {
+			remaining[e]--
+			aligned = append(aligned, e)
+		}
+	}
+	for _, e := range apiElems {
+		if remaining[e] > 0 {
+			remaining[e]--
+			aligned = append(aligned, e)
+		}
+	}
+
+	if slices.Equal(aligned, apiElems) {
+		return apiList, false
+	}
+
+	alignedList, diags := types.ListValueFrom(ctx, types.StringType, aligned)
+	if diags.HasError() {
+		return apiList, false
+	}
+	return alignedList, true
+}
+
 // preserveAutoRemediationListOrder prevents spurious diffs caused by the API returning
+// the elements of a list attribute in an order that differs from the configured order.
 func (r *policyDrivenPRResource) preserveAutoRemediationListOrder(ctx context.Context, currentStateOptions autoRemdiationOptionsModel, state *policyDrivenPRModel) {
 	if state.AutoRemdiationOptions.IsNull() || state.AutoRemdiationOptions.IsUnknown() {
 		return
@@ -1987,43 +2058,29 @@ func (r *policyDrivenPRResource) preserveAutoRemediationListOrder(ctx context.Co
 	attrs := state.AutoRemdiationOptions.Attributes()
 	changed := false
 
-	// preserveOrder replaces attrs[key] with stateList when both contain the same elements.
+	// preserveOrder rewrites attrs[key] so it follows stateList's ordering.
 	preserveOrder := func(key string, stateList types.List) {
-		if stateList.IsNull() || stateList.IsUnknown() {
+		apiList, ok := attrs[key].(types.List)
+		if !ok {
 			return
 		}
-		newList, ok := attrs[key].(types.List)
-		if !ok || newList.IsNull() || newList.IsUnknown() {
+		aligned, ok := alignListOrder(ctx, stateList, apiList)
+		if !ok {
 			return
 		}
-
-		stateElems := make([]string, 0, len(stateList.Elements()))
-		for _, e := range stateList.Elements() {
-			stateElems = append(stateElems, e.(types.String).ValueString())
-		}
-		newElems := make([]string, 0, len(newList.Elements()))
-		for _, e := range newList.Elements() {
-			newElems = append(newElems, e.(types.String).ValueString())
-		}
-
-		if len(stateElems) != len(newElems) {
-			return
-		}
-		stateSorted := make([]string, len(stateElems))
-		copy(stateSorted, stateElems)
-		newSorted := make([]string, len(newElems))
-		copy(newSorted, newElems)
-		slices.Sort(stateSorted)
-		slices.Sort(newSorted)
-		if slices.Equal(stateSorted, newSorted) {
-			attrs[key] = stateList
-			changed = true
-		}
+		attrs[key] = aligned
+		changed = true
 	}
 
 	preserveOrder("actions_to_replace_with_step_security_actions", currentStateOptions.ActionsToReplaceWithStepSecurityActions)
 	preserveOrder("actions_to_exempt_while_pinning", currentStateOptions.ActionsToExemptWhilePinning)
 	preserveOrder("images_to_exempt_while_pinning", currentStateOptions.ImagesToExemptWhilePinning)
+	preserveOrder("actions_exempted_from_replacement", currentStateOptions.ExemptedFromReplacement)
+	preserveOrder("update_precommit_file", currentStateOptions.UpdatePrecommitFile)
+
+	if r.preserveHardenRunnerLabelOrder(ctx, currentStateOptions, attrs) {
+		changed = true
+	}
 
 	if !changed {
 		return
@@ -2040,4 +2097,45 @@ func (r *policyDrivenPRResource) preserveAutoRemediationListOrder(ctx context.Co
 		return
 	}
 	state.AutoRemdiationOptions = updatedObj
+}
+
+// preserveHardenRunnerLabelOrder applies the same ordering fix to
+// harden_runner_config.target_runner_labels, which lives one level down in a nested
+// object. It mutates attrs in place and reports whether it changed anything.
+func (r *policyDrivenPRResource) preserveHardenRunnerLabelOrder(ctx context.Context, currentStateOptions autoRemdiationOptionsModel, attrs map[string]attr.Value) bool {
+	stateConfig := currentStateOptions.HardenRunnerConfig
+	if stateConfig.IsNull() || stateConfig.IsUnknown() {
+		return false
+	}
+	var stateModel hardenRunnerConfigModel
+	if diags := stateConfig.As(ctx, &stateModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return false
+	}
+
+	apiConfig, ok := attrs["harden_runner_config"].(types.Object)
+	if !ok || apiConfig.IsNull() || apiConfig.IsUnknown() {
+		return false
+	}
+	configAttrs := apiConfig.Attributes()
+	apiLabels, ok := configAttrs["target_runner_labels"].(types.List)
+	if !ok {
+		return false
+	}
+
+	aligned, ok := alignListOrder(ctx, stateModel.RunnerLabels, apiLabels)
+	if !ok {
+		return false
+	}
+	configAttrs["target_runner_labels"] = aligned
+
+	objType, ok := apiConfig.Type(ctx).(basetypes.ObjectType)
+	if !ok {
+		return false
+	}
+	updatedConfig, diags := types.ObjectValue(objType.AttrTypes, configAttrs)
+	if diags.HasError() {
+		return false
+	}
+	attrs["harden_runner_config"] = updatedConfig
+	return true
 }

--- a/internal/provider/resource_policy_driven_pr.go
+++ b/internal/provider/resource_policy_driven_pr.go
@@ -401,8 +401,8 @@ func (r *policyDrivenPRResource) ImportState(ctx context.Context, req resource.I
 				map[string]attr.Value{
 					"package":       types.StringValue(ecosystem.Package),
 					"interval":      types.StringValue(ecosystem.Interval),
-					"cooldown_yaml": types.StringValue(ecosystem.CoolDownYAML),
-					"groups_yaml":   types.StringValue(ecosystem.GroupsYAML),
+					"cooldown_yaml": stringOrNull(ecosystem.CoolDownYAML),
+					"groups_yaml":   stringOrNull(ecosystem.GroupsYAML),
 				},
 			)
 			ecosystemObjects = append(ecosystemObjects, obj)
@@ -562,7 +562,7 @@ func (r *policyDrivenPRResource) ImportState(ctx context.Context, req resource.I
 							"target_runner_labels":          types.ListType{ElemType: types.StringType},
 						},
 						map[string]attr.Value{
-							"config":                        types.StringValue(policy.AutoRemdiationOptions.HardenRunnerConfig.Config),
+							"config":                        stringOrNull(policy.AutoRemdiationOptions.HardenRunnerConfig.Config),
 							"update_existing_configuration": types.BoolValue(policy.AutoRemdiationOptions.HardenRunnerConfig.Subtractive),
 							"target_runner_labels":          labelsList,
 						},
@@ -1773,8 +1773,8 @@ func (r *policyDrivenPRResource) updatePolicyDrivenPRState(ctx context.Context, 
 				map[string]attr.Value{
 					"package":       types.StringValue(ecosystem.Package),
 					"interval":      types.StringValue(ecosystem.Interval),
-					"cooldown_yaml": types.StringValue(ecosystem.CoolDownYAML),
-					"groups_yaml":   types.StringValue(ecosystem.GroupsYAML),
+					"cooldown_yaml": stringOrNull(ecosystem.CoolDownYAML),
+					"groups_yaml":   stringOrNull(ecosystem.GroupsYAML),
 				},
 			)
 			ecosystemObjects = append(ecosystemObjects, obj)
@@ -1934,7 +1934,7 @@ func (r *policyDrivenPRResource) updatePolicyDrivenPRState(ctx context.Context, 
 							"target_runner_labels":          types.ListType{ElemType: types.StringType},
 						},
 						map[string]attr.Value{
-							"config":                        types.StringValue(stepSecurityPolicy.AutoRemdiationOptions.HardenRunnerConfig.Config),
+							"config":                        stringOrNull(stepSecurityPolicy.AutoRemdiationOptions.HardenRunnerConfig.Config),
 							"update_existing_configuration": types.BoolValue(stepSecurityPolicy.AutoRemdiationOptions.HardenRunnerConfig.Subtractive),
 							"target_runner_labels":          labelsList,
 						},
@@ -1976,6 +1976,21 @@ func (r *policyDrivenPRResource) updatePolicyDrivenPRState(ctx context.Context, 
 		excludedList, _ := types.ListValueFrom(ctx, types.StringType, excludedElements)
 		state.ExcludedRepos = excludedList
 	}
+}
+
+// stringOrNull maps an absent API string to null rather than to the empty string.
+//
+// cooldown_yaml, groups_yaml and harden_runner_config.config are Optional with no
+// default, so a configuration that omits them holds null. All three are omitempty on the
+// wire, so the API returns them absent and Go decodes that to "". Writing types.StringValue("")
+// into state therefore disagrees with the plan on every refresh. Terraform counts that as
+// a change but renders empty-string-vs-null as unchanged, producing a plan that reports
+// "1 to change" with no attribute diff shown at all.
+func stringOrNull(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
 }
 
 // listToStrings extracts a []string from a types.List of strings, skipping any

--- a/internal/provider/resource_policy_driven_pr_order_test.go
+++ b/internal/provider/resource_policy_driven_pr_order_test.go
@@ -191,3 +191,47 @@ func TestAlignListOrderHandlesDuplicates(t *testing.T) {
 	require.True(t, changed)
 	assert.Equal(t, []string{"b", "a", "b"}, listValues(t, aligned))
 }
+
+// TestReadMapsAbsentOptionalStringsToNull pins the null-vs-empty-string mapping for the
+// Optional string attributes that have no default. The API omits them (omitempty), so Go
+// decodes them to "", and writing that into state disagrees with a configuration that
+// leaves them unset on every single refresh. Terraform then reports a change it renders as
+// nothing at all: "Plan: 0 to add, 1 to change, 0 to destroy" with every attribute listed
+// as unchanged.
+func TestReadMapsAbsentOptionalStringsToNull(t *testing.T) {
+	ctx := context.Background()
+	r := &policyDrivenPRResource{}
+
+	apiPolicy := stepsecurityapi.PolicyDrivenPRPolicy{
+		Owner: "test-org",
+		AutoRemdiationOptions: stepsecurityapi.AutoRemdiationOptions{
+			PackageEcosystem: []stepsecurityapi.DependabotConfig{
+				{Package: "npm", Interval: "daily"},
+				{Package: "pip", Interval: "weekly", CoolDownYAML: "days: 7"},
+			},
+			HardenRunnerConfig: &stepsecurityapi.HardenRunnerConfig{},
+		},
+		SelectedRepos: []string{"repo-a"},
+	}
+
+	var state policyDrivenPRModel
+	r.updatePolicyDrivenPRState(ctx, apiPolicy, &state, []string{"repo-a"}, nil)
+
+	options := readStateOptions(t, state)
+
+	var ecosystems []packageEcosystemModel
+	diags := options.PackageEcosystem.ElementsAs(ctx, &ecosystems, false)
+	require.False(t, diags.HasError(), "decoding package_ecosystem: %v", diags)
+	require.Len(t, ecosystems, 2)
+
+	assert.True(t, ecosystems[0].CoolDownYAML.IsNull(), "npm cooldown_yaml should be null, got %q", ecosystems[0].CoolDownYAML.ValueString())
+	assert.True(t, ecosystems[0].GroupsYAML.IsNull(), "npm groups_yaml should be null, got %q", ecosystems[0].GroupsYAML.ValueString())
+	assert.True(t, ecosystems[1].GroupsYAML.IsNull(), "pip groups_yaml should be null, got %q", ecosystems[1].GroupsYAML.ValueString())
+	// A value the API does return must still come through untouched.
+	assert.Equal(t, "days: 7", ecosystems[1].CoolDownYAML.ValueString(), "pip cooldown_yaml")
+
+	var hardenRunner hardenRunnerConfigModel
+	diags = options.HardenRunnerConfig.As(ctx, &hardenRunner, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError(), "decoding harden_runner_config: %v", diags)
+	assert.True(t, hardenRunner.Config.IsNull(), "harden_runner_config.config should be null, got %q", hardenRunner.Config.ValueString())
+}

--- a/internal/provider/resource_policy_driven_pr_order_test.go
+++ b/internal/provider/resource_policy_driven_pr_order_test.go
@@ -1,0 +1,193 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stepsecurityapi "github.com/step-security/terraform-provider-stepsecurity/internal/stepsecurity-api"
+)
+
+// hardenRunnerConfigObjectType mirrors the harden_runner_config attribute type used by
+// the resource schema.
+func hardenRunnerConfigObjectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: map[string]attr.Type{
+		"config":                        types.StringType,
+		"update_existing_configuration": types.BoolType,
+		"target_runner_labels":          types.ListType{ElemType: types.StringType},
+	}}
+}
+
+func testStringList(t *testing.T, values ...string) types.List {
+	t.Helper()
+	list, diags := types.ListValueFrom(context.Background(), types.StringType, values)
+	require.False(t, diags.HasError(), "building list: %v", diags)
+	return list
+}
+
+func testHardenRunnerConfig(t *testing.T, labels ...string) types.Object {
+	t.Helper()
+	obj, diags := types.ObjectValue(
+		hardenRunnerConfigObjectType().AttrTypes,
+		map[string]attr.Value{
+			"config":                        types.StringValue("egress-policy: audit"),
+			"update_existing_configuration": types.BoolValue(false),
+			"target_runner_labels":          testStringList(t, labels...),
+		},
+	)
+	require.False(t, diags.HasError(), "building harden_runner_config: %v", diags)
+	return obj
+}
+
+// readStateOptions decodes the auto_remediation_options object a read produced.
+func readStateOptions(t *testing.T, state policyDrivenPRModel) autoRemdiationOptionsModel {
+	t.Helper()
+	var options autoRemdiationOptionsModel
+	diags := state.AutoRemdiationOptions.As(context.Background(), &options, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError(), "decoding auto_remediation_options: %v", diags)
+	return options
+}
+
+func listValues(t *testing.T, list types.List) []string {
+	t.Helper()
+	require.False(t, list.IsNull(), "expected a known list, got null")
+	require.False(t, list.IsUnknown(), "expected a known list, got unknown")
+	return listToStrings(list)
+}
+
+// TestReadPreservesConfiguredListOrder pins that a read leaves every order-insensitive
+// list attribute in the order the practitioner configured it.
+//
+// The API stores actions_to_replace and update_precommit_file as JSON objects, so the
+// read path derives those lists from a Go map range. GetPolicyDrivenPRPolicy sorts them
+// so that two reads of a byte-identical response agree with each other (see #47/#78), but
+// sorting alone is not enough: a configuration whose elements are not already in
+// alphabetical order still gets a permanent reordering diff, because the sorted read
+// never matches the configured order. The read has to realign to the prior state.
+func TestReadPreservesConfiguredListOrder(t *testing.T) {
+	ctx := context.Background()
+	r := &policyDrivenPRResource{}
+
+	// The practitioner's configured order, deliberately not alphabetical.
+	configuredPrecommit := []string{"eslint", "gitleaks", "php-lint-all", "shellcheck", "trailing-whitespace", "end-of-file-fixer"}
+	configuredReplace := []string{"actions/setup-node", "actions/checkout"}
+	configuredExemptActions := []string{"zzz/action", "aaa/action"}
+	configuredExemptImages := []string{"ubuntu:latest", "alpine:3.19"}
+	configuredExemptedFromReplacement := []string{"my-org/keep-this", "another-org/keep-this-too"}
+	configuredRunnerLabels := []string{"self-hosted-large", "self-hosted"}
+
+	currentStateOptions := autoRemdiationOptionsModel{
+		ActionsToExemptWhilePinning:             testStringList(t, configuredExemptActions...),
+		ImagesToExemptWhilePinning:              testStringList(t, configuredExemptImages...),
+		ActionsToReplaceWithStepSecurityActions: testStringList(t, configuredReplace...),
+		ExemptedFromReplacement:                 testStringList(t, configuredExemptedFromReplacement...),
+		UpdatePrecommitFile:                     testStringList(t, configuredPrecommit...),
+		HardenRunnerConfig:                      testHardenRunnerConfig(t, configuredRunnerLabels...),
+	}
+
+	// What the API layer hands back: the same elements, sorted.
+	apiPolicy := stepsecurityapi.PolicyDrivenPRPolicy{
+		Owner: "test-org",
+		AutoRemdiationOptions: stepsecurityapi.AutoRemdiationOptions{
+			ActionsToExemptWhilePinning:             []string{"aaa/action", "zzz/action"},
+			ImagesToExemptWhilePinning:              []string{"alpine:3.19", "ubuntu:latest"},
+			ActionsToReplaceWithStepSecurityActions: []string{"actions/checkout", "actions/setup-node"},
+			ExemptedFromReplacement:                 []string{"another-org/keep-this-too", "my-org/keep-this"},
+			UpdatePrecommitFile:                     []string{"end-of-file-fixer", "eslint", "gitleaks", "php-lint-all", "shellcheck", "trailing-whitespace"},
+			HardenRunnerConfig: &stepsecurityapi.HardenRunnerConfig{
+				Config:       "egress-policy: audit",
+				RunnerLabels: []string{"self-hosted", "self-hosted-large"},
+			},
+		},
+		SelectedRepos: []string{"repo-a"},
+	}
+
+	var state policyDrivenPRModel
+	r.updatePolicyDrivenPRState(ctx, apiPolicy, &state, []string{"repo-a"}, nil)
+	r.preserveAutoRemediationListOrder(ctx, currentStateOptions, &state)
+
+	options := readStateOptions(t, state)
+	assert.Equal(t, configuredPrecommit, listValues(t, options.UpdatePrecommitFile), "update_precommit_file")
+	assert.Equal(t, configuredReplace, listValues(t, options.ActionsToReplaceWithStepSecurityActions), "actions_to_replace_with_step_security_actions")
+	assert.Equal(t, configuredExemptActions, listValues(t, options.ActionsToExemptWhilePinning), "actions_to_exempt_while_pinning")
+	assert.Equal(t, configuredExemptImages, listValues(t, options.ImagesToExemptWhilePinning), "images_to_exempt_while_pinning")
+	assert.Equal(t, configuredExemptedFromReplacement, listValues(t, options.ExemptedFromReplacement), "actions_exempted_from_replacement")
+
+	var hardenRunner hardenRunnerConfigModel
+	diags := options.HardenRunnerConfig.As(ctx, &hardenRunner, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError(), "decoding harden_runner_config: %v", diags)
+	assert.Equal(t, configuredRunnerLabels, listValues(t, hardenRunner.RunnerLabels), "harden_runner_config.target_runner_labels")
+}
+
+// TestReadKeepsConfiguredOrderWhenMembershipChanges covers the case the previous
+// same-elements-only reconciliation gave up on: when the live config genuinely differs
+// from state, the elements that survive must still keep their configured positions, so
+// the plan shows only the real add/remove rather than a wholesale reshuffle.
+func TestReadKeepsConfiguredOrderWhenMembershipChanges(t *testing.T) {
+	ctx := context.Background()
+	r := &policyDrivenPRResource{}
+
+	currentStateOptions := autoRemdiationOptionsModel{
+		UpdatePrecommitFile: testStringList(t, "trailing-whitespace", "eslint", "gitleaks"),
+	}
+
+	apiPolicy := stepsecurityapi.PolicyDrivenPRPolicy{
+		Owner: "test-org",
+		AutoRemdiationOptions: stepsecurityapi.AutoRemdiationOptions{
+			// "gitleaks" was removed out of band and "shellcheck" added; the rest is
+			// what GetPolicyDrivenPRPolicy returns after sorting.
+			UpdatePrecommitFile: []string{"eslint", "shellcheck", "trailing-whitespace"},
+		},
+		SelectedRepos: []string{"repo-a"},
+	}
+
+	var state policyDrivenPRModel
+	r.updatePolicyDrivenPRState(ctx, apiPolicy, &state, []string{"repo-a"}, nil)
+	r.preserveAutoRemediationListOrder(ctx, currentStateOptions, &state)
+
+	options := readStateOptions(t, state)
+	assert.Equal(t,
+		[]string{"trailing-whitespace", "eslint", "shellcheck"},
+		listValues(t, options.UpdatePrecommitFile),
+		"survivors keep their configured order and the new element is appended")
+}
+
+// TestReadWithEmptyPriorStateLeavesApiOrder makes sure the realignment is inert when
+// there is nothing to realign to, e.g. right after an import.
+func TestReadWithEmptyPriorStateLeavesApiOrder(t *testing.T) {
+	ctx := context.Background()
+	r := &policyDrivenPRResource{}
+
+	apiPolicy := stepsecurityapi.PolicyDrivenPRPolicy{
+		Owner: "test-org",
+		AutoRemdiationOptions: stepsecurityapi.AutoRemdiationOptions{
+			UpdatePrecommitFile: []string{"eslint", "gitleaks"},
+		},
+		SelectedRepos: []string{"repo-a"},
+	}
+
+	var state policyDrivenPRModel
+	r.updatePolicyDrivenPRState(ctx, apiPolicy, &state, []string{"repo-a"}, nil)
+	r.preserveAutoRemediationListOrder(ctx, autoRemdiationOptionsModel{}, &state)
+
+	options := readStateOptions(t, state)
+	assert.Equal(t, []string{"eslint", "gitleaks"}, listValues(t, options.UpdatePrecommitFile))
+}
+
+// TestAlignListOrderHandlesDuplicates pins the multiset behaviour: a repeated element
+// must not be dropped or multiplied by the realignment.
+func TestAlignListOrderHandlesDuplicates(t *testing.T) {
+	ctx := context.Background()
+
+	stateList := testStringList(t, "b", "a", "b")
+	apiList := testStringList(t, "a", "b", "b")
+
+	aligned, changed := alignListOrder(ctx, stateList, apiList)
+	require.True(t, changed)
+	assert.Equal(t, []string{"b", "a", "b"}, listValues(t, aligned))
+}

--- a/internal/provider/resource_policy_driven_pr_plan_stability_test.go
+++ b/internal/provider/resource_policy_driven_pr_plan_stability_test.go
@@ -1,0 +1,203 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// fakePolicyDrivenPRBackend is a stand-in for the policy-driven PR API that stores
+// exactly what the provider writes and hands it back verbatim on read.
+//
+// The point is to isolate the provider. The POST body (policyDrivenPRConfigOptions) and
+// the GET response's policy_driven_pr_configuration (policyDrivenPRInternal) are the same
+// object, so echoing the stored write is what a lossless backend looks like. Any plan that
+// is non-empty after a clean apply against this backend is therefore a provider-side
+// round-trip defect, not backend behaviour.
+type fakePolicyDrivenPRBackend struct {
+	mu      sync.Mutex
+	configs map[string]json.RawMessage // repo -> stored config
+	v2      bool
+}
+
+func newFakePolicyDrivenPRBackend(v2Enabled bool) *fakePolicyDrivenPRBackend {
+	return &fakePolicyDrivenPRBackend{
+		configs: map[string]json.RawMessage{},
+		v2:      v2Enabled,
+	}
+}
+
+func (b *fakePolicyDrivenPRBackend) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Paths: /v1/github/{owner}/{repo}/policy-driven-pr/configs
+	//        /v1/github/{owner}/{repo}/actions/subscription-status
+	parts := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+	if len(parts) < 4 {
+		http.Error(w, "unexpected path", http.StatusNotFound)
+		return
+	}
+	owner, repo := parts[2], parts[3]
+	tail := strings.Join(parts[4:], "/")
+
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case tail == "actions/subscription-status":
+		fmt.Fprintf(w, `{"tier":"enterprise","status":"active","app_feature_flags":{"is_policy_driven_pr_v2_enabled":%t}}`, b.v2)
+
+	case tail == "policy-driven-pr/configs" && req.Method == http.MethodPost:
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, "unreadable body", http.StatusBadRequest)
+			return
+		}
+		b.mu.Lock()
+		b.configs[repo] = json.RawMessage(body)
+		b.mu.Unlock()
+		fmt.Fprint(w, `{"status":200,"state":"completed"}`)
+
+	case tail == "policy-driven-pr/configs" && req.Method == http.MethodGet:
+		b.mu.Lock()
+		stored, ok := b.configs[repo]
+		b.mu.Unlock()
+		if !ok {
+			fmt.Fprint(w, `{"repos":[]}`)
+			return
+		}
+		fmt.Fprintf(w, `{"repos":[{"full_repo_name":"%s/%s","policy_driven_pr_configuration":%s}]}`, owner, repo, stored)
+
+	case tail == "policy-driven-pr/configs" && req.Method == http.MethodDelete:
+		b.mu.Lock()
+		delete(b.configs, repo)
+		b.mu.Unlock()
+		fmt.Fprint(w, `{}`)
+
+	default:
+		http.Error(w, "unexpected request: "+req.Method+" "+req.URL.Path, http.StatusNotFound)
+	}
+}
+
+// phase7Fixture mirrors the complex-scenario fixture from the integration-test suite
+// (terraform/scenarios/policy_driven_pr_suite.go, GetComplexFixture), which is the one
+// still reporting "Plan is not stable" after a clean apply.
+const phase7Fixture = `
+resource "stepsecurity_policy_driven_pr" "test" {
+  owner          = "step-terraform-tests"
+  selected_repos = ["test-repo-one"]
+
+  auto_remediation_options = {
+    create_pr = true
+
+    harden_github_hosted_runner = true
+
+    pin_actions_to_sha              = true
+    actions_to_exempt_while_pinning = ["actions/*", "github/*"]
+
+    restrict_github_token_permissions = true
+
+    actions_to_replace_with_step_security_actions = [
+      "amannn/action-semantic-pull-request",
+      "crazy-max/ghaction-import-gpg",
+      "fkirc/skip-duplicate-actions"
+    ]
+
+    add_workflows = "https://github.com/step-security/secure-repo"
+
+    update_precommit_file = ["gitleaks", "shellcheck", "trailing-whitespace"]
+
+    secure_docker_file = true
+
+    package_ecosystem = [
+      {
+        package  = "npm"
+        interval = "daily"
+      },
+      {
+        package  = "pip"
+        interval = "weekly"
+      }
+    ]
+  }
+}
+`
+
+func testAccPolicyDrivenPRAgainstFake(t *testing.T, backend *fakePolicyDrivenPRBackend, config string) {
+	t.Helper()
+
+	server := httptest.NewServer(backend)
+	t.Cleanup(server.Close)
+
+	t.Setenv("TF_ACC", "1")
+	t.Setenv("STEP_SECURITY_API_BASE_URL", server.URL)
+	t.Setenv("STEP_SECURITY_API_KEY", "test-key")
+	t.Setenv("STEP_SECURITY_CUSTOMER", "test-customer")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				// The harness plans again after applying and fails the step when that
+				// plan is non-empty, which is the same assertion the integration test's
+				// idempotency check makes.
+			},
+		},
+	})
+}
+
+// TestAccPolicyDrivenPRPhase7PlanIsEmptyAfterApply reproduces the integration suite's
+// Phase 7 idempotency check against a lossless backend. Terraform reported "Plan: 0 to
+// add, 1 to change, 0 to destroy" with every attribute rendered as unchanged, which points
+// at a value the provider writes back in a form the configuration cannot produce: the
+// package_ecosystem entries came back with cooldown_yaml and groups_yaml as "" where the
+// configuration holds null.
+func TestAccPolicyDrivenPRPhase7PlanIsEmptyAfterApply(t *testing.T) {
+	testAccPolicyDrivenPRAgainstFake(t, newFakePolicyDrivenPRBackend(true), phase7Fixture)
+}
+
+// unsortedListsFixture is the configuration from
+// terraform-provider-stepsecurity#47: an update_precommit_file whose order is not
+// alphabetical, which is what the sort in #78 alone could not converge on.
+const unsortedListsFixture = `
+resource "stepsecurity_policy_driven_pr" "test" {
+  owner          = "step-terraform-tests"
+  selected_repos = ["test-repo-one"]
+
+  auto_remediation_options = {
+    create_pr                         = true
+    pin_actions_to_sha                = true
+    restrict_github_token_permissions = true
+    harden_github_hosted_runner       = true
+    secure_docker_file                = true
+
+    update_precommit_file = [
+      "eslint",
+      "gitleaks",
+      "php-lint-all",
+      "shellcheck",
+      "trailing-whitespace",
+      "end-of-file-fixer",
+    ]
+
+    actions_to_replace_with_step_security_actions = [
+      "fkirc/skip-duplicate-actions",
+      "amannn/action-semantic-pull-request",
+    ]
+
+    actions_to_exempt_while_pinning = ["github/*", "actions/*"]
+  }
+}
+`
+
+// TestAccPolicyDrivenPRUnsortedListsPlanIsEmptyAfterApply is the end-to-end version of
+// issue #47: the practitioner's list order is not alphabetical, so the read has to realign
+// to it rather than merely being self-consistent.
+func TestAccPolicyDrivenPRUnsortedListsPlanIsEmptyAfterApply(t *testing.T) {
+	testAccPolicyDrivenPRAgainstFake(t, newFakePolicyDrivenPRBackend(true), unsortedListsFixture)
+}

--- a/internal/provider/resource_policy_driven_pr_plan_stability_test.go
+++ b/internal/provider/resource_policy_driven_pr_plan_stability_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -130,10 +132,30 @@ resource "stepsecurity_policy_driven_pr" "test" {
 func testAccPolicyDrivenPRAgainstFake(t *testing.T, backend *fakePolicyDrivenPRBackend, config string) {
 	t.Helper()
 
+	// Resolve a Terraform CLI before enabling acceptance mode, and pin it via
+	// TF_ACC_TERRAFORM_PATH so the harness uses it directly.
+	//
+	// Without this the harness falls back to downloading a CLI through hc-install, which
+	// fails on any runner that has no terraform installed - currently with "unable to
+	// verify checksums signature: openpgp: key expired", because the HashiCorp release
+	// signing key embedded in hc-install v0.9.2 has expired. These tests are otherwise
+	// hermetic (the backend is an httptest server), so skipping when there is no CLI
+	// keeps `go test ./...` offline and self-contained rather than failing on a network
+	// download nobody asked for.
+	tfPath := os.Getenv("TF_ACC_TERRAFORM_PATH")
+	if tfPath == "" {
+		found, err := exec.LookPath("terraform")
+		if err != nil {
+			t.Skip("terraform CLI not found in PATH; set TF_ACC_TERRAFORM_PATH to run this test")
+		}
+		tfPath = found
+	}
+
 	server := httptest.NewServer(backend)
 	t.Cleanup(server.Close)
 
 	t.Setenv("TF_ACC", "1")
+	t.Setenv("TF_ACC_TERRAFORM_PATH", tfPath)
 	t.Setenv("STEP_SECURITY_API_BASE_URL", server.URL)
 	t.Setenv("STEP_SECURITY_API_KEY", "test-key")
 	t.Setenv("STEP_SECURITY_CUSTOMER", "test-customer")


### PR DESCRIPTION
## Summary

Two independent causes of the perpetual drift in `stepsecurity_policy_driven_pr`. Follow-up to #78 for #47, plus the separate defect that kept the integration suite's Phase 7 idempotency check red after that.

## 1. Ordering: sorting is not the same as matching the configured order

#78 sorted the two map-derived lists in the API layer, which made each read *self-consistent* — the element no longer rotates randomly between plans. But `update_precommit_file` is an order-significant Terraform list, so sorting only matches the practitioner's order when their configuration happens to be alphabetical. The reproducer in #47 is not: its list ends `"trailing-whitespace", "end-of-file-fixer"`, so every plan moved `end-of-file-fixer` to the front. The random diff became a permanent one.

The read path already had the right mechanism — `preserveAutoRemediationListOrder`, which restores the prior state's ordering — it just was not wired to the attribute from the issue.

- Wire `update_precommit_file` and `actions_exempted_from_replacement` into the reconciliation, plus the nested `harden_runner_config.target_runner_labels`.
- New `alignListOrder`: keep shared elements in their configured positions and append API-only elements at the end. The previous logic bailed out entirely unless the two lists held exactly the same elements, so the moment the backend added or dropped one entry the sorted order leaked into the plan as a wholesale reshuffle on top of the real change. Genuine adds and removes still surface; the reordering noise does not. Uses multiset counting so duplicate elements survive intact.

## 2. Empty string where the configuration holds null

Phase 7 of the integration suite still failed, with a plan that reads `Plan: 0 to add, 1 to change, 0 to destroy` and lists **every** attribute as unchanged. Nothing was rendered because the difference was empty-string-vs-null, which Terraform counts as a change but displays as nothing. Every list in that fixture is already alphabetical, so this was never the ordering path.

Reproduced locally against a fake backend that echoes back exactly what the provider wrote — proving the defect is provider-side, not backend behaviour — then read the plan JSON to see what the renderer was hiding:

```
auto_remediation_options.package_ecosystem[0].cooldown_yaml  "" -> null
auto_remediation_options.package_ecosystem[0].groups_yaml    "" -> null
auto_remediation_options.package_ecosystem[1].cooldown_yaml  "" -> null
auto_remediation_options.package_ecosystem[1].groups_yaml    "" -> null
```

`cooldown_yaml`, `groups_yaml` and `harden_runner_config.config` are `Optional` with no default, so a configuration that omits them holds null; all three are `omitempty` on the wire, so the API returns them absent and Go decodes that to `""`. Writing `types.StringValue("")` into state therefore disagreed with the plan on every refresh. They now go through `stringOrNull`, in both the read path and the import path.

## Validation

- `go build ./...`, `gofmt -l internal/`, `go vet`, `go test -race ./...` — all pass.
- Unit tests drive the real `updatePolicyDrivenPRState` → `preserveAutoRemediationListOrder` path: configured order preserved across all five lists plus the nested one, order held when membership genuinely changes, inert with empty prior state (import), duplicate handling, and the null mapping for the optional strings.
- Plan-stability tests reproduce both integration fixtures — Phase 7 and the non-alphabetical one from #47 — against a hermetic `httptest` fake backend, asserting an empty plan after a clean apply. No live API needed; they gate on `TF_ACC` like the other acceptance tests.
- Every new test was checked to be non-vacuous: with its corresponding fix reverted, the ordering tests reproduce the exact diff from #47 (`end-of-file-fixer` jumping to the front) and the Phase 7 test reproduces the invisible `1 to change`.

## Known limitations, not addressed here

`ImportState` has no prior state to realign against, so imported lists come back sorted. That is deterministic, but `ImportStateVerify` against a resource created from a non-alphabetical configuration will still report a mismatch. Fixing that properly means moving these attributes from `List` to `Set`, which is a schema change worth deciding on separately.

`stepsecurity_github_checks` has the same same-elements-only weakness in `updateStateListsWithOrderFromPlan`, and its `controls` reconciliation returns early when a planned control is missing from state. Different resource, left alone here.