### PR TITLE
feat(github-policy-store): add denied_endpoints support

### DIFF
--- a/docs/resources/github_policy_store.md
+++ b/docs/resources/github_policy_store.md
@@ -53,13 +53,15 @@ resource "stepsecurity_github_policy_store" "custom-policy" {
 
 # Policy with block mode and a deny list instead of an allow list.
 # denied_endpoints cannot be set together with allowed_endpoints.
+# Unlike allowed_endpoints, denied_endpoints does not take a port -
+# entries are hostnames only (e.g. "evil.example.com", not "evil.example.com:443").
 resource "stepsecurity_github_policy_store" "denied-endpoints-policy" {
   owner         = "test-organization"
   policy_name   = "denied-endpoints-policy"
   egress_policy = "block"
   denied_endpoints = [
-    "evil.example.com:443",
-    "malware.example.org:443"
+    "evil.example.com",
+    "malware.example.org"
   ]
 }
 
@@ -116,7 +118,7 @@ import {
 ### Optional
 
 - `allowed_endpoints` (List of String) List of allowed endpoints. This specifies list of enpoints to allow when egress policy is set to 'block' mode
-- `denied_endpoints` (Set of String) Set of denied endpoints. This specifies endpoints to deny when egress policy is set to 'block' mode. Cannot be set together with allowed_endpoints.
+- `denied_endpoints` (Set of String) Set of denied endpoints (hostnames only, e.g. 'evil.example.com'). Unlike allowed_endpoints, a port is not required and has no effect if included. This specifies endpoints to deny when egress policy is set to 'block' mode. Cannot be set together with allowed_endpoints.
 - `disable_file_monitoring` (Boolean) This disables file monitoring
 - `disable_sudo` (Boolean) This disables sudo access for HardenRunner agent
 - `disable_telemetry` (Boolean) This disables telemetry collection.

--- a/docs/resources/github_policy_store.md
+++ b/docs/resources/github_policy_store.md
@@ -51,6 +51,18 @@ resource "stepsecurity_github_policy_store" "custom-policy" {
   ]
 }
 
+# Policy with block mode and a deny list instead of an allow list.
+# denied_endpoints cannot be set together with allowed_endpoints.
+resource "stepsecurity_github_policy_store" "denied-endpoints-policy" {
+  owner         = "test-organization"
+  policy_name   = "denied-endpoints-policy"
+  egress_policy = "block"
+  denied_endpoints = [
+    "evil.example.com:443",
+    "malware.example.org:443"
+  ]
+}
+
 # Policy with lockdown enabled for all detections
 resource "stepsecurity_github_policy_store" "lockdown-all" {
   owner         = "test-organization"
@@ -104,6 +116,7 @@ import {
 ### Optional
 
 - `allowed_endpoints` (List of String) List of allowed endpoints. This specifies list of enpoints to allow when egress policy is set to 'block' mode
+- `denied_endpoints` (Set of String) Set of denied endpoints. This specifies endpoints to deny when egress policy is set to 'block' mode. Cannot be set together with allowed_endpoints.
 - `disable_file_monitoring` (Boolean) This disables file monitoring
 - `disable_sudo` (Boolean) This disables sudo access for HardenRunner agent
 - `disable_telemetry` (Boolean) This disables telemetry collection.

--- a/examples/resources/stepsecurity_github_policy_store/resource.tf
+++ b/examples/resources/stepsecurity_github_policy_store/resource.tf
@@ -38,13 +38,15 @@ resource "stepsecurity_github_policy_store" "custom-policy" {
 
 # Policy with block mode and a deny list instead of an allow list.
 # denied_endpoints cannot be set together with allowed_endpoints.
+# Unlike allowed_endpoints, denied_endpoints does not take a port -
+# entries are hostnames only (e.g. "evil.example.com", not "evil.example.com:443").
 resource "stepsecurity_github_policy_store" "denied-endpoints-policy" {
   owner         = "test-organization"
   policy_name   = "denied-endpoints-policy"
   egress_policy = "block"
   denied_endpoints = [
-    "evil.example.com:443",
-    "malware.example.org:443"
+    "evil.example.com",
+    "malware.example.org"
   ]
 }
 

--- a/examples/resources/stepsecurity_github_policy_store/resource.tf
+++ b/examples/resources/stepsecurity_github_policy_store/resource.tf
@@ -36,6 +36,18 @@ resource "stepsecurity_github_policy_store" "custom-policy" {
   ]
 }
 
+# Policy with block mode and a deny list instead of an allow list.
+# denied_endpoints cannot be set together with allowed_endpoints.
+resource "stepsecurity_github_policy_store" "denied-endpoints-policy" {
+  owner         = "test-organization"
+  policy_name   = "denied-endpoints-policy"
+  egress_policy = "block"
+  denied_endpoints = [
+    "evil.example.com:443",
+    "malware.example.org:443"
+  ]
+}
+
 # Policy with lockdown enabled for all detections
 resource "stepsecurity_github_policy_store" "lockdown-all" {
   owner         = "test-organization"

--- a/internal/provider/resource_github_policy_store.go
+++ b/internal/provider/resource_github_policy_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -20,9 +21,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &githubPolicyStoreResource{}
-	_ resource.ResourceWithConfigure   = &githubPolicyStoreResource{}
-	_ resource.ResourceWithImportState = &githubPolicyStoreResource{}
+	_ resource.Resource                   = &githubPolicyStoreResource{}
+	_ resource.ResourceWithConfigure      = &githubPolicyStoreResource{}
+	_ resource.ResourceWithImportState    = &githubPolicyStoreResource{}
+	_ resource.ResourceWithValidateConfig = &githubPolicyStoreResource{}
 )
 
 // NewOrderResource is a helper function to simplify the provider implementation.
@@ -76,6 +78,18 @@ func (r *githubPolicyStoreResource) Schema(_ context.Context, _ resource.SchemaR
 					),
 				),
 				Description: "List of allowed endpoints. This specifies list of enpoints to allow when egress policy is set to 'block' mode",
+			},
+			"denied_endpoints": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Computed:    true,
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						types.StringType,
+						[]attr.Value{},
+					),
+				),
+				Description: "Set of denied endpoints. This specifies endpoints to deny when egress policy is set to 'block' mode. Cannot be set together with allowed_endpoints.",
 			},
 			"disable_telemetry": schema.BoolAttribute{
 				Optional:    true,
@@ -151,12 +165,45 @@ func (r *githubPolicyStoreResource) Configure(ctx context.Context, req resource.
 	r.client = client
 }
 
+// ValidateConfig implements resource.ResourceWithValidateConfig.
+func (r *githubPolicyStoreResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var model githubPolicyStoreModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Defer validation until both are fully known — avoids erroring on
+	// partially-unknown config (e.g. values derived from other resources).
+	if model.AllowedEndpoints.IsUnknown() || model.DeniedEndpoints.IsUnknown() {
+		return
+	}
+
+	allowedLen := 0
+	if !model.AllowedEndpoints.IsNull() {
+		allowedLen = len(model.AllowedEndpoints.Elements())
+	}
+	deniedLen := 0
+	if !model.DeniedEndpoints.IsNull() {
+		deniedLen = len(model.DeniedEndpoints.Elements())
+	}
+
+	if allowedLen > 0 && deniedLen > 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("denied_endpoints"),
+			"Conflicting endpoint lists",
+			"`allowed_endpoints` and `denied_endpoints` cannot both be set. Use one or the other.",
+		)
+	}
+}
+
 type githubPolicyStoreModel struct {
 	ID                    types.String `tfsdk:"id"`
 	Owner                 types.String `tfsdk:"owner"`
 	PolicyName            types.String `tfsdk:"policy_name"`
 	EgressPolicy          types.String `tfsdk:"egress_policy"`
 	AllowedEndpoints      types.List   `tfsdk:"allowed_endpoints"`
+	DeniedEndpoints       types.Set    `tfsdk:"denied_endpoints"`
 	DisableTelemetry      types.Bool   `tfsdk:"disable_telemetry"`
 	DisableSudo           types.Bool   `tfsdk:"disable_sudo"`
 	DisableFileMonitoring types.Bool   `tfsdk:"disable_file_monitoring"`
@@ -342,12 +389,21 @@ func (r *githubPolicyStoreResource) updateGitHubPolicyStorePolicyState(policy *s
 		allowedEndpoints = append(allowedEndpoints, types.StringValue(endpoint))
 	}
 
+	var deniedEndpoints []attr.Value
+	for _, endpoint := range policy.DeniedEndpoints {
+		deniedEndpoints = append(deniedEndpoints, types.StringValue(endpoint))
+	}
+
 	state.ID = types.StringValue(policy.Owner + ":::" + policy.PolicyName)
 	state.Owner = types.StringValue(policy.Owner)
 	state.PolicyName = types.StringValue(policy.PolicyName)
 	state.AllowedEndpoints = types.ListValueMust(
 		types.StringType,
 		allowedEndpoints,
+	)
+	state.DeniedEndpoints = types.SetValueMust(
+		types.StringType,
+		deniedEndpoints,
 	)
 	state.EgressPolicy = types.StringValue(policy.EgressPolicy)
 	state.DisableTelemetry = types.BoolValue(policy.DisableTelemetry)
@@ -383,6 +439,11 @@ func (r *githubPolicyStoreResource) getGitHubPolicyStorePolicy(ctx context.Conte
 		allowedEndpoints = append(allowedEndpoints, ep.(types.String).ValueString())
 	}
 
+	var deniedEndpoints []string
+	for _, ep := range plan.DeniedEndpoints.Elements() {
+		deniedEndpoints = append(deniedEndpoints, ep.(types.String).ValueString())
+	}
+
 	var lockdownConfig *stepsecurityapi.LockdownConfig
 	if !plan.Lockdown.IsNull() && !plan.Lockdown.IsUnknown() {
 		var lm lockdownConfigModel
@@ -409,6 +470,7 @@ func (r *githubPolicyStoreResource) getGitHubPolicyStorePolicy(ctx context.Conte
 		Owner:                 plan.Owner.ValueString(),
 		PolicyName:            plan.PolicyName.ValueString(),
 		AllowedEndpoints:      allowedEndpoints,
+		DeniedEndpoints:       deniedEndpoints,
 		EgressPolicy:          plan.EgressPolicy.ValueString(),
 		DisableTelemetry:      plan.DisableTelemetry.ValueBool(),
 		DisableSudo:           plan.DisableSudo.ValueBool(),

--- a/internal/provider/resource_github_policy_store.go
+++ b/internal/provider/resource_github_policy_store.go
@@ -89,7 +89,7 @@ func (r *githubPolicyStoreResource) Schema(_ context.Context, _ resource.SchemaR
 						[]attr.Value{},
 					),
 				),
-				Description: "Set of denied endpoints. This specifies endpoints to deny when egress policy is set to 'block' mode. Cannot be set together with allowed_endpoints.",
+				Description: "Set of denied endpoints (hostnames only, e.g. 'evil.example.com'). Unlike allowed_endpoints, a port is not required and has no effect if included. This specifies endpoints to deny when egress policy is set to 'block' mode. Cannot be set together with allowed_endpoints.",
 			},
 			"disable_telemetry": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/provider/resource_github_policy_store_test.go
+++ b/internal/provider/resource_github_policy_store_test.go
@@ -120,6 +120,26 @@ func TestAccGithubPolicyStoreResourceMinimal(t *testing.T) {
 	})
 }
 
+func TestAccGithubPolicyStoreResourceWithDeniedEndpoints(t *testing.T) {
+	res.Test(t, res.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []res.TestStep{
+			{
+				Config: testAccGithubPolicyStoreResourceConfigWithDeniedEndpoints("tf-acc-test", "test-policy-denied"),
+				Check: res.ComposeAggregateTestCheckFunc(
+					res.TestCheckResourceAttr("stepsecurity_github_policy_store.test", "owner", "tf-acc-test"),
+					res.TestCheckResourceAttr("stepsecurity_github_policy_store.test", "policy_name", "test-policy-denied"),
+					res.TestCheckResourceAttr("stepsecurity_github_policy_store.test", "egress_policy", "block"),
+					res.TestCheckResourceAttr("stepsecurity_github_policy_store.test", "denied_endpoints.#", "2"),
+					res.TestCheckTypeSetElemAttr("stepsecurity_github_policy_store.test", "denied_endpoints.*", "evil.example.com:443"),
+					res.TestCheckTypeSetElemAttr("stepsecurity_github_policy_store.test", "denied_endpoints.*", "malware.example.org:443"),
+				),
+			},
+		},
+	})
+}
+
 func TestGithubPolicyStoreResource_Metadata(t *testing.T) {
 	t.Parallel()
 
@@ -178,7 +198,7 @@ func TestGithubPolicyStoreResource_Schema(t *testing.T) {
 
 	// Test required attributes
 	expectedAttrs := []string{
-		"id", "owner", "policy_name", "egress_policy", "allowed_endpoints",
+		"id", "owner", "policy_name", "egress_policy", "allowed_endpoints", "denied_endpoints",
 		"disable_telemetry", "disable_sudo", "disable_file_monitoring",
 	}
 	for _, attr := range expectedAttrs {
@@ -353,6 +373,120 @@ func TestGithubPolicyStoreResource_ClientInteraction(t *testing.T) {
 	}
 }
 
+func TestGithubPolicyStoreResource_ValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		allowedEndpoints types.List
+		deniedEndpoints  types.Set
+		expectedError    bool
+	}{
+		{
+			name:             "neither_set",
+			allowedEndpoints: types.ListNull(types.StringType),
+			deniedEndpoints:  types.SetNull(types.StringType),
+			expectedError:    false,
+		},
+		{
+			name: "only_allowed_set",
+			allowedEndpoints: types.ListValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("github.com:443")},
+			),
+			deniedEndpoints: types.SetNull(types.StringType),
+			expectedError:   false,
+		},
+		{
+			name:             "only_denied_set",
+			allowedEndpoints: types.ListNull(types.StringType),
+			deniedEndpoints: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("evil.example.com:443")},
+			),
+			expectedError: false,
+		},
+		{
+			name: "both_empty",
+			allowedEndpoints: types.ListValueMust(
+				types.StringType,
+				[]attr.Value{},
+			),
+			deniedEndpoints: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{},
+			),
+			expectedError: false,
+		},
+		{
+			name: "both_set",
+			allowedEndpoints: types.ListValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("github.com:443")},
+			),
+			deniedEndpoints: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{types.StringValue("evil.example.com:443")},
+			),
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			r := &githubPolicyStoreResource{}
+
+			schemaResp := &resource.SchemaResponse{}
+			r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected schema diagnostics: %v", schemaResp.Diagnostics)
+			}
+
+			model := githubPolicyStoreModel{
+				ID:                    types.StringValue("test-org:::test-policy"),
+				Owner:                 types.StringValue("test-org"),
+				PolicyName:            types.StringValue("test-policy"),
+				EgressPolicy:          types.StringValue("block"),
+				AllowedEndpoints:      tc.allowedEndpoints,
+				DeniedEndpoints:       tc.deniedEndpoints,
+				DisableTelemetry:      types.BoolValue(false),
+				DisableSudo:           types.BoolValue(false),
+				DisableFileMonitoring: types.BoolValue(false),
+				Lockdown: types.ObjectNull(map[string]attr.Type{
+					"enabled":                   types.BoolType,
+					"privileged_container":      types.BoolType,
+					"runner_worker_memory_read": types.BoolType,
+					"reverse_shell":             types.BoolType,
+				}),
+			}
+
+			plan := tfsdk.Plan{Schema: schemaResp.Schema}
+			diags := plan.Set(ctx, model)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics building config: %v", diags)
+			}
+
+			config := tfsdk.Config{Raw: plan.Raw, Schema: schemaResp.Schema}
+			resp := &resource.ValidateConfigResponse{}
+
+			r.ValidateConfig(ctx, resource.ValidateConfigRequest{Config: config}, resp)
+
+			if tc.expectedError {
+				if !resp.Diagnostics.HasError() {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if resp.Diagnostics.HasError() {
+					t.Errorf("Expected no error but got: %v", resp.Diagnostics)
+				}
+			}
+		})
+	}
+}
+
 func TestGithubPolicyStoreResource_ImportState(t *testing.T) {
 	t.Parallel()
 
@@ -429,6 +563,9 @@ func TestGithubPolicyStoreResource_ImportState(t *testing.T) {
 							"allowed_endpoints": tftypes.List{
 								ElementType: tftypes.String,
 							},
+							"denied_endpoints": tftypes.Set{
+								ElementType: tftypes.String,
+							},
 							"disable_telemetry":       tftypes.Bool,
 							"disable_sudo":            tftypes.Bool,
 							"disable_file_monitoring": tftypes.Bool,
@@ -494,6 +631,10 @@ func TestGithubPolicyStoreResource_UpdateState(t *testing.T) {
 					types.StringType,
 					[]attr.Value{types.StringValue("github.com:443")},
 				),
+				DeniedEndpoints: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{},
+				),
 				DisableTelemetry:      types.BoolValue(false),
 				DisableSudo:           types.BoolValue(false),
 				DisableFileMonitoring: types.BoolValue(false),
@@ -523,9 +664,40 @@ func TestGithubPolicyStoreResource_UpdateState(t *testing.T) {
 						types.StringValue("registry.npmjs.org:443"),
 					},
 				),
+				DeniedEndpoints: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{},
+				),
 				DisableTelemetry:      types.BoolValue(true),
 				DisableSudo:           types.BoolValue(true),
 				DisableFileMonitoring: types.BoolValue(true),
+			},
+		},
+		{
+			name: "policy_with_denied_endpoints",
+			policy: &stepsecurityapi.GitHubPolicyStorePolicy{
+				Owner:            "tf-acc-test",
+				PolicyName:       "test-policy-denied",
+				EgressPolicy:     "block",
+				AllowedEndpoints: []string{},
+				DeniedEndpoints:  []string{"evil.example.com:443", "malware.example.org:443"},
+			},
+			expected: githubPolicyStoreModel{
+				ID:           types.StringValue("tf-acc-test:::test-policy-denied"),
+				Owner:        types.StringValue("tf-acc-test"),
+				PolicyName:   types.StringValue("test-policy-denied"),
+				EgressPolicy: types.StringValue("block"),
+				AllowedEndpoints: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{},
+				),
+				DeniedEndpoints: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("evil.example.com:443"),
+						types.StringValue("malware.example.org:443"),
+					},
+				),
 			},
 		},
 	}
@@ -573,6 +745,11 @@ func TestGithubPolicyStoreResource_UpdateState(t *testing.T) {
 			if len(state.AllowedEndpoints.Elements()) != len(tc.expected.AllowedEndpoints.Elements()) {
 				t.Errorf("Expected %d allowed endpoints, got %d", len(tc.expected.AllowedEndpoints.Elements()), len(state.AllowedEndpoints.Elements()))
 			}
+
+			// Verify set elements count
+			if len(state.DeniedEndpoints.Elements()) != len(tc.expected.DeniedEndpoints.Elements()) {
+				t.Errorf("Expected %d denied endpoints, got %d", len(tc.expected.DeniedEndpoints.Elements()), len(state.DeniedEndpoints.Elements()))
+			}
 		})
 	}
 }
@@ -595,6 +772,10 @@ func TestGithubPolicyStoreResource_GetPolicy(t *testing.T) {
 					types.StringType,
 					[]attr.Value{types.StringValue("github.com:443")},
 				),
+				DeniedEndpoints: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{},
+				),
 				DisableTelemetry:      types.BoolValue(false),
 				DisableSudo:           types.BoolValue(false),
 				DisableFileMonitoring: types.BoolValue(false),
@@ -604,6 +785,7 @@ func TestGithubPolicyStoreResource_GetPolicy(t *testing.T) {
 				PolicyName:            "test-policy",
 				EgressPolicy:          "audit",
 				AllowedEndpoints:      []string{"github.com:443"},
+				DeniedEndpoints:       []string{},
 				DisableTelemetry:      false,
 				DisableSudo:           false,
 				DisableFileMonitoring: false,
@@ -623,6 +805,10 @@ func TestGithubPolicyStoreResource_GetPolicy(t *testing.T) {
 						types.StringValue("registry.npmjs.org:443"),
 					},
 				),
+				DeniedEndpoints: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{},
+				),
 				DisableTelemetry:      types.BoolValue(true),
 				DisableSudo:           types.BoolValue(true),
 				DisableFileMonitoring: types.BoolValue(true),
@@ -632,9 +818,36 @@ func TestGithubPolicyStoreResource_GetPolicy(t *testing.T) {
 				PolicyName:            "test-policy",
 				EgressPolicy:          "block",
 				AllowedEndpoints:      []string{"github.com:443", "api.github.com:443", "registry.npmjs.org:443"},
+				DeniedEndpoints:       []string{},
 				DisableTelemetry:      true,
 				DisableSudo:           true,
 				DisableFileMonitoring: true,
+			},
+		},
+		{
+			name: "model_with_denied_endpoints",
+			model: githubPolicyStoreModel{
+				Owner:        types.StringValue("tf-acc-test"),
+				PolicyName:   types.StringValue("test-policy-denied"),
+				EgressPolicy: types.StringValue("block"),
+				AllowedEndpoints: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{},
+				),
+				DeniedEndpoints: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("evil.example.com:443"),
+						types.StringValue("malware.example.org:443"),
+					},
+				),
+			},
+			expected: &stepsecurityapi.GitHubPolicyStorePolicy{
+				Owner:            "tf-acc-test",
+				PolicyName:       "test-policy-denied",
+				EgressPolicy:     "block",
+				AllowedEndpoints: []string{},
+				DeniedEndpoints:  []string{"evil.example.com:443", "malware.example.org:443"},
 			},
 		},
 	}
@@ -665,6 +878,23 @@ func TestGithubPolicyStoreResource_GetPolicy(t *testing.T) {
 			for i, endpoint := range result.AllowedEndpoints {
 				if endpoint != tc.expected.AllowedEndpoints[i] {
 					t.Errorf("Expected endpoint %s at index %d, got %s", tc.expected.AllowedEndpoints[i], i, endpoint)
+				}
+			}
+
+			// Set ordering is not guaranteed, so compare membership rather than index.
+			if len(result.DeniedEndpoints) != len(tc.expected.DeniedEndpoints) {
+				t.Errorf("Expected %d denied endpoints, got %d", len(tc.expected.DeniedEndpoints), len(result.DeniedEndpoints))
+			}
+			for _, expectedEndpoint := range tc.expected.DeniedEndpoints {
+				found := false
+				for _, endpoint := range result.DeniedEndpoints {
+					if endpoint == expectedEndpoint {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected denied endpoint %s not found in result: %v", expectedEndpoint, result.DeniedEndpoints)
 				}
 			}
 
@@ -724,6 +954,21 @@ resource "stepsecurity_github_policy_store" "test" {
   disable_telemetry       = true
   disable_sudo            = true
   disable_file_monitoring = true
+}
+`, owner, policyName)
+}
+
+func testAccGithubPolicyStoreResourceConfigWithDeniedEndpoints(owner, policyName string) string {
+	return testProviderConfig() + fmt.Sprintf(`
+resource "stepsecurity_github_policy_store" "test" {
+  owner         = %[1]q
+  policy_name   = %[2]q
+  egress_policy = "block"
+
+  denied_endpoints = [
+    "evil.example.com:443",
+    "malware.example.org:443"
+  ]
 }
 `, owner, policyName)
 }

--- a/internal/stepsecurity-api/gh-policy-store.go
+++ b/internal/stepsecurity-api/gh-policy-store.go
@@ -29,6 +29,7 @@ type GitHubPolicyStorePolicy struct {
 	Owner                 string             `json:"owner"`
 	PolicyName            string             `json:"policyName"`
 	AllowedEndpoints      []string           `json:"allowed_endpoints"`
+	DeniedEndpoints       []string           `json:"denied_endpoints,omitempty"`
 	EgressPolicy          string             `json:"egress_policy"`
 	DisableTelemetry      bool               `json:"disable_telemetry"`
 	DisableSudo           bool               `json:"disable_sudo"`
@@ -52,6 +53,7 @@ func (c *APIClient) CreateGitHubPolicyStorePolicy(ctx context.Context, policy *G
 		Owner:                 policy.Owner,
 		PolicyName:            policy.PolicyName,
 		AllowedEndpoints:      policy.AllowedEndpoints,
+		DeniedEndpoints:       policy.DeniedEndpoints,
 		EgressPolicy:          policy.EgressPolicy,
 		DisableTelemetry:      policy.DisableTelemetry,
 		DisableSudo:           policy.DisableSudo,


### PR DESCRIPTION
## Summary
- Adds `denied_endpoints` to `stepsecurity_github_policy_store` as an alternative to `allowed_endpoints`, mirroring a backend addition to the Harden Runner policy API (`denied_endpoints` on `PolicyDetails`).
- Modeled as a `Set` (not `List`) since order is meaningless for a deny-list and this avoids perpetual plan diffs from any backend-side dedup/reordering.
- Adds client-side `ValidateConfig` that rejects configs with both `allowed_endpoints` and `denied_endpoints` set, mirroring the backend's own `hasConflictingEndpointLists` check.

## Changes
- `internal/stepsecurity-api/gh-policy-store.go`: add `DeniedEndpoints` field to `GitHubPolicyStorePolicy` (and the create-request struct).
- `internal/provider/resource_github_policy_store.go`: add `denied_endpoints` schema attribute, model field, flatten/expand logic, and a new `ValidateConfig` method.
- `internal/provider/resource_github_policy_store_test.go`: extend unit tests (`Schema`, `UpdateState`, `GetPolicy`, `ImportState`) and add a new `ValidateConfig` unit test plus an acceptance test.
- `examples/resources/stepsecurity_github_policy_store/resource.tf` + regenerated `docs/resources/github_policy_store.md`: add a `denied_endpoints` example.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` / `gofmt`
- [x] `go test ./...` and `go test -race ./internal/provider/ -run TestGithubPolicyStoreResource`
- [x] `golangci-lint run` (no new issues)
- [ ] `TF_ACC=1 go test ./internal/provider/ -run TestAccGithubPolicyStoreResource -v` against a live backend (not run here — no backend credentials in this environment)